### PR TITLE
Use Publish API in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/raft v1.0.0
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/liftbridge-io/go-liftbridge v0.0.0-20190628041033-36ed3eee7846
+	github.com/liftbridge-io/go-liftbridge v0.0.0-20190628050631-26acc07f31ba
 	github.com/liftbridge-io/nats-on-a-log v0.0.0-20180718011723-80d0727461af
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
 	github.com/nats-io/gnatsd v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/liftbridge-io/go-liftbridge v0.0.0-20181231191109-b4f9a50124b8 h1:c5g
 github.com/liftbridge-io/go-liftbridge v0.0.0-20181231191109-b4f9a50124b8/go.mod h1:L65jj77HzuFnBmcohb0ztVw9KtMvr2Fe4aUJZferdY0=
 github.com/liftbridge-io/go-liftbridge v0.0.0-20190628041033-36ed3eee7846 h1:ZNqgh2iD19JmyWlOPW+al3nbE4ftl52K/yciuCPVEO4=
 github.com/liftbridge-io/go-liftbridge v0.0.0-20190628041033-36ed3eee7846/go.mod h1:L65jj77HzuFnBmcohb0ztVw9KtMvr2Fe4aUJZferdY0=
+github.com/liftbridge-io/go-liftbridge v0.0.0-20190628050631-26acc07f31ba h1:QvW103/O/7dsdAlmPZaqHVob1JK7NxxQirlKkxocAwI=
+github.com/liftbridge-io/go-liftbridge v0.0.0-20190628050631-26acc07f31ba/go.mod h1:L65jj77HzuFnBmcohb0ztVw9KtMvr2Fe4aUJZferdY0=
 github.com/liftbridge-io/nats-on-a-log v0.0.0-20180718011723-80d0727461af h1:2m2YbqghQzLF+8uWDMbrFvCK5FBHOdarbywK9v6tclE=
 github.com/liftbridge-io/nats-on-a-log v0.0.0-20180718011723-80d0727461af/go.mod h1:4tC6R+N3facyfCwDuuuLkFF/25ceiZEwoQUzIez2dVo=
 github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc h1:7xGrl4tTpBQu5Zjll08WupHyq+Sp0Z/adtyf1cfk3Q8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/hashicorp/raft
 github.com/hashicorp/raft-boltdb
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences
-# github.com/liftbridge-io/go-liftbridge v0.0.0-20190628041033-36ed3eee7846
+# github.com/liftbridge-io/go-liftbridge v0.0.0-20190628050631-26acc07f31ba
 github.com/liftbridge-io/go-liftbridge/liftbridge-grpc
 github.com/liftbridge-io/go-liftbridge
 # github.com/liftbridge-io/nats-on-a-log v0.0.0-20180718011723-80d0727461af


### PR DESCRIPTION
Replace low-level NATS publishes with the new Liftbridge Publish API.