### PR TITLE
Suppress logs during Raft recovery by default

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -102,6 +102,7 @@ the setting in the configuration file and the CLI flag if it exists.
 | tls.key | tls-key | The private key file for server certificate. This must be set in combination with `tls.cert` to enable TLS. | string | |
 | tls.cert | tls-cert | The server certificate file. This must be set in combination with `tls.key` to enable TLS. | string | |
 | log.level | level | The logging level. | string | info | [debug, info, warn, error] |
+| log.recovery | | Log messages resulting from the replay of the Raft log on server recovery. | bool | false | |
 | data.dir | data-dir | The directory to store data in. | string | /tmp/liftbridge/namespace | |
 | batch.max.messages | | The maximum number of messages to batch when writing to disk. | int | 1024 |
 | batch.wait.time | | The time to wait to batch more messages when writing to disk. | duration | 0 | |

--- a/server/commitlog/commitlog.go
+++ b/server/commitlog/commitlog.go
@@ -16,7 +16,6 @@ import (
 
 	atomic_file "github.com/natefinch/atomic"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/liftbridge-io/liftbridge/server/logger"
 	"github.com/liftbridge-io/liftbridge/server/proto"
@@ -71,7 +70,8 @@ func New(opts Options) (*CommitLog, error) {
 	}
 
 	if opts.Logger == nil {
-		opts.Logger = &log.Logger{Out: ioutil.Discard}
+		opts.Logger = logger.NewLogger(0)
+		opts.Logger.SetWriter(ioutil.Discard)
 	}
 
 	if opts.MaxSegmentBytes == 0 {

--- a/server/commitlog/delete_cleaner_test.go
+++ b/server/commitlog/delete_cleaner_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/liftbridge-io/liftbridge/server/logger"
@@ -13,7 +12,9 @@ import (
 )
 
 func noopLogger() logger.Logger {
-	return &log.Logger{Out: ioutil.Discard}
+	log := logger.NewLogger(0)
+	log.SetWriter(ioutil.Discard)
+	return log
 }
 
 func createSegment(t require.TestingT, dir string, baseOffset, maxBytes int64) *Segment {

--- a/server/common_test.go
+++ b/server/common_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"runtime"
 	"strings"
 	"sync"
@@ -73,3 +75,9 @@ func (c *captureFatalLogger) Fatalf(format string, args ...interface{}) {
 	}
 	c.Unlock()
 }
+
+func (c *captureFatalLogger) Writer() io.Writer {
+	return bytes.NewBufferString(c.msg)
+}
+
+func (c *captureFatalLogger) SetWriter(writer io.Writer) {}

--- a/server/config.go
+++ b/server/config.go
@@ -99,7 +99,8 @@ type Config struct {
 	Host                string
 	Port                int
 	LogLevel            uint32
-	NoLog               bool
+	LogRecovery         bool
+	LogSilent           bool
 	DataDir             string
 	BatchMaxMessages    int
 	BatchWaitTime       time.Duration
@@ -189,6 +190,8 @@ func NewConfig(configFile string) (*Config, error) {
 				return nil, err
 			}
 			config.LogLevel = level
+		case "log.recovery":
+			config.LogRecovery = v.(bool)
 		case "data.dir":
 			config.DataDir = v.(string)
 		case "batch.max.messages":

--- a/server/logger/logger.go
+++ b/server/logger/logger.go
@@ -1,5 +1,12 @@
 package logger
 
+import (
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Logger interface is used to allow tests to inject custom loggers.
 type Logger interface {
 	Fatalf(string, ...interface{})
 	Debugf(string, ...interface{})
@@ -10,4 +17,30 @@ type Logger interface {
 	Warn(...interface{})
 	Info(...interface{})
 	Fatal(...interface{})
+	Writer() io.Writer
+	SetWriter(io.Writer)
+}
+
+type logger struct {
+	*log.Logger
+}
+
+// NewLogger returns a new Logger instance backed by Logrus.
+func NewLogger(level uint32) Logger {
+	l := log.New()
+	l.SetLevel(log.Level(level))
+	logFormatter := &log.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: "2006-01-02 15:04:05",
+	}
+	l.Formatter = logFormatter
+	return &logger{l}
+}
+
+func (l *logger) Writer() io.Writer {
+	return l.Out
+}
+
+func (l *logger) SetWriter(writer io.Writer) {
+	l.Out = writer
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,7 +43,7 @@ func getTestConfig(id string, bootstrap bool, port int) *Config {
 	config.Clustering.RaftLogging = true
 	config.LogLevel = uint32(log.DebugLevel)
 	config.NATS.Servers = []string{"nats://localhost:4222"}
-	config.NoLog = true
+	config.LogSilent = true
 	config.Port = port
 	return config
 }


### PR DESCRIPTION
Also add new config option `log.recovery` to allow enabling logs during
Raft recovery.