### PR TITLE
Removing unnecessary `go get`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk update && apk upgrade && \
 ADD . /go/src/github.com/liftbridge-io/liftbridge
 WORKDIR /go/src/github.com/liftbridge-io/liftbridge
 ENV GO111MODULE on
-RUN go get
 RUN GOOS=linux GOARCH=amd64 go build
 
 FROM alpine:latest


### PR DESCRIPTION
As pointed out in [his](https://github.com/liftbridge-io/liftbridge/pull/84#discussion_r307193292) comment by @annismckenzie, calling `go get` is not needed. Sorry for opening new PR for this same issue again, I meant to update the Dockerfile yesterday but I had to finish  early.