### PR TITLE
Added client authentication via certificate

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -35,6 +35,8 @@ GLOBAL OPTIONS:
    --port value, -p value                      port to bind to (default: 9292)
    --tls-cert value                            server certificate file
    --tls-key value                             private key for server certificate
+   --tls-client-auth value                     enforce client authentication
+   --tls-client-auth-ca value                  CA certificate to use when authenticating clients
    --level value, -l value                     logging level [debug|info|warn|error] (default: "info")
    --raft-bootstrap-seed                       bootstrap the Raft cluster by electing self as leader if there is no existing state
    --raft-bootstrap-peers value                bootstrap the Raft cluster with the provided list of peer IDs if there is no existing state
@@ -101,6 +103,8 @@ the setting in the configuration file and the CLI flag if it exists.
 | port | port | The server port. | int | 9292 | |
 | tls.key | tls-key | The private key file for server certificate. This must be set in combination with `tls.cert` to enable TLS. | string | |
 | tls.cert | tls-cert | The server certificate file. This must be set in combination with `tls.key` to enable TLS. | string | |
+| tls.client.auth | tls-client-auth | Enforce client-side authentication via certificate. | bool | false |
+| tls.client.auth.ca | tls-client-auth-ca | The CA certificate file to use when authenticating clients. | string | |
 | log.level | level | The logging level. | string | info | [debug, info, warn, error] |
 | log.recovery | | Log messages resulting from the replay of the Raft log on server recovery. | bool | false | |
 | data.dir | data-dir | The directory to store data in. | string | /tmp/liftbridge/namespace | |

--- a/main.go
+++ b/main.go
@@ -61,6 +61,12 @@ func main() {
 		if c.IsSet("tls-key") {
 			config.TLSKey = c.String("tls-key")
 		}
+		if c.IsSet("tls-client-auth") {
+			config.TLSClientAuth = c.Bool("tls-client-auth")
+		}
+		if c.IsSet("tls-client-auth-ca") {
+			config.TLSClientAuthCA = c.String("tls-client-auth-ca")
+		}
 		if c.IsSet("nats-servers") {
 			natsServers, err := normalizeNatsServers(c.StringSlice("nats-servers"))
 			if err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -110,6 +110,8 @@ type Config struct {
 	MetadataCacheMaxAge time.Duration
 	TLSKey              string
 	TLSCert             string
+	TLSClientAuth       bool
+	TLSClientAuthCA     string
 	NATS                nats.Options
 	Log                 LogConfig
 	Clustering          ClusteringConfig
@@ -253,6 +255,10 @@ func NewConfig(configFile string) (*Config, error) {
 			config.TLSKey = v.(string)
 		case "tls.cert":
 			config.TLSCert = v.(string)
+		case "tls.client.auth":
+			config.TLSClientAuth = v.(bool)
+		case "tls.client.auth.ca":
+			config.TLSClientAuthCA = v.(string)
 		case "nats":
 			if err := parseNATSConfig(v.(map[string]interface{}), &config.NATS); err != nil {
 				return nil, err


### PR DESCRIPTION
This PR adds client authentication via TLS certificate. The Liftbridge server can enforce client authentication using the tls.client.auth configuration entry or command line parameter. The CA certificate to use when authenticating clients can also be specified.

No unit tests have been written because none existed regarding TLS. Can add some if needed. What are your thoughts about that @tylertreat?