### PR TITLE
Fix liftbridge dev compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,6 @@ kind-export:
 build:
 	@ GO111MODULE=on CGO_ENABLED=0 go build -mod=readonly -o liftbridge
 
-build-dev:
-	@ GO111MODULE=on CGO_ENABLED=1 go build -mod=readonly -o liftbridge-dev
+build-dev: liftbridge-dev
+liftbridge-dev:
+	CGO_ENABLED=1 go build -tags netgo -ldflags '-extldflags "-static"' -mod=readonly -o liftbridge-dev

--- a/docker/dev-standalone/Dockerfile
+++ b/docker/dev-standalone/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update && apk upgrade && \
 WORKDIR /workspace
 
 ENV GO111MODULE on
+RUN go get github.com/liftbridge-io/liftbridge
 RUN go get github.com/nats-io/nats-server/v2
 
 COPY docker/dev-standalone/ docker/dev-standalone/
@@ -13,13 +14,13 @@ COPY liftbridge-dev liftbridge-dev
 FROM alpine:latest
 COPY --from=build-base /workspace/liftbridge-dev /usr/local/bin/liftbridge
 COPY --from=build-base /go/bin/nats-server /usr/local/bin/nats-server
-COPY --from=build-base /workspace/docker/dev-standalone/nats-server.conf nats-server.conf
 
-# Expose Liftbridge and Nats: client, management and routing
 EXPOSE 9292 4222 8222 6222
+
 VOLUME "/tmp/liftbridge/liftbridge-default"
 
-COPY --from=build-base /workspace/docker/dev-standalone/script_runner.sh script_runner.sh
+COPY docker/dev-standalone/nats-server.conf nats-server.conf
+COPY docker/dev-standalone/script_runner.sh script_runner.sh
 
 RUN chmod +x script_runner.sh
 CMD ./script_runner.sh


### PR DESCRIPTION
Needed to be statically linked to work when copied to the docker image. Current image is toutputting "liftbridge: Not found" and exiting.