### PR TITLE
Fix no metadata leader race

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -76,14 +76,14 @@ func TestCreateStreamPropagate(t *testing.T) {
 	s2 := runServerWithConfig(t, s2Config)
 	defer s2.Stop()
 
-	getMetadataLeader(t, 10*time.Second, s1, s2)
-
 	// Connect and send the request to the follower.
 	client, err := lift.Connect([]string{"localhost:5050"})
 	require.NoError(t, err)
 	defer client.Close()
 
-	err = client.CreateStream(context.Background(), "foo", "foo")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = client.CreateStream(ctx, "foo", "foo")
 	require.NoError(t, err)
 
 	// Creating the same stream returns ErrStreamExists.

--- a/server/metadata.go
+++ b/server/metadata.go
@@ -684,8 +684,17 @@ func (m *metadataAPI) propagateReportLeader(ctx context.Context, req *proto.Repo
 // propagateRequest forwards a metadata request to the metadata leader and
 // returns the response.
 func (m *metadataAPI) propagateRequest(ctx context.Context, req *proto.PropagatedRequest) *status.Status {
-	// Fail fast if there is no known metadata leader currently.
-	if m.getRaft().Leader() == "" {
+	// Check if there is currently a metadata leader.
+	for {
+		if m.getRaft().Leader() != "" {
+			break
+		}
+		// Wait up to deadline for a metadata leader to be established.
+		deadline, _ := ctx.Deadline()
+		if time.Now().Before(deadline) {
+			time.Sleep(2 * time.Millisecond)
+			continue
+		}
 		return status.New(codes.Internal, "No known metadata leader")
 	}
 


### PR DESCRIPTION
Use the context deadline on CreateStream to wait for a metadata leader
to be established during CreateStream propagation.

This fixes #163.