### PR TITLE
Fix RPC propagation race edge case

### DIFF
--- a/server/api_test.go
+++ b/server/api_test.go
@@ -123,7 +123,7 @@ func TestCreateStreamNoMetadataLeader(t *testing.T) {
 	err = client.CreateStream(context.Background(), "foo", "foo")
 	require.Error(t, err)
 	st := status.Convert(err)
-	require.Equal(t, "No known metadata leader", st.Message())
+	require.Equal(t, "no known metadata leader", st.Message())
 	require.Equal(t, codes.Internal, st.Code())
 }
 


### PR DESCRIPTION
Fix a race condition edge case on RPC propagation where an RPC is made
when there is no metadata leader. If the server receiving the RPC
becomes leader, it may propagate the request to itself before the
propagation NATS subscription has been established. In this case, the
propagated RPC is missed and the original RPC times out.

To fix this, we check if the server receiving the RPC has become the
metadata leader. If it has, there is no need to propagate the request as
it can be performed locally.