### PR TITLE
Allow overriding viper config with env vars

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -73,6 +73,7 @@ An example configuration file is shown below.
 ```yaml
 ---
 listen: localhost:9293
+host: localhost
 data.dir: /tmp/liftbridge/server-2
 activity.stream.enabled: true
 
@@ -98,6 +99,21 @@ clustering:
   server.id: server-2
   raft.bootstrap.seed: true
   replica.max.lag.time: 20s
+```
+
+## Overriding configuration settings with environment variables
+
+For configuration set in the configuration file the value can be overridden
+with environment variables prefixed with `LIFTBRIDGE_`. The key must exist in
+the config file to be overridden.
+
+For example using the config file from above one could override the host and
+logging level with:
+
+```sh
+env LIFTBRIDGE_HOST=liftbridge.example.com \
+  LIFTBRIDGE_LOGGING_LEVEL=error \
+  liftbridge --config config.yaml
 ```
 
 ## Configuration Settings

--- a/server/config.go
+++ b/server/config.go
@@ -327,6 +327,10 @@ func NewConfig(configFile string) (*Config, error) { // nolint: gocyclo
 	v.SetConfigFile(configFile)
 	v.SetConfigType("yaml")
 
+	// Allow overriding config with environment variables
+	v.SetEnvPrefix("LIFTBRIDGE")
+	v.AutomaticEnv()
+
 	// Parse the config file.
 	if err := v.ReadInConfig(); err != nil {
 		return nil, errors.Wrap(err, "Failed to load configuration file")


### PR DESCRIPTION
For example with a config.yml of:

```yml
host: localhost
```

One can override the advertised host with:

```sh
env LIFTBRIDGE_HOST=liftbridge-0.liftbridge-headless \
  liftbridge --raft-bootstrap-seed --config config.yml
```

I stumbled upon this trying to run the standalone-dev container inside
docker-compose where I was using the virtual network hostnames to wire
everything together. Which lead me to these issues:

https://github.com/liftbridge-io/go-liftbridge/issues/33
https://github.com/liftbridge-io/liftbridge/issues/138

The initial connection was fine but the advertised host in the metadata
returned from liftbridge was `127.0.0.1` so when the go-liftbridge
client further went to connect to the "brokers" it would fail.

I'm pretty sure people would struggle to get this working with
statefulsets unless different config files were being injected per
replica that defined the host properly.

With this change the `LIFTBRIDGE_HOST` env var could be passed into the
pod more easily.