### PR TITLE
Fix dev-standalone build

### DIFF
--- a/docker/dev-standalone/Dockerfile
+++ b/docker/dev-standalone/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.13-alpine as build-base
 RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh make bzr
+    apk add --no-cache bash git openssh make
 
 WORKDIR /workspace
 


### PR DESCRIPTION
bzr is no longer available in Alpine Linux as of 3.12
(https://github.com/alpinelinux/docker-alpine/issues/87).