### PR TITLE
Fix data waiter race in replication causing high tail latencies

### DIFF
--- a/server/replicator.go
+++ b/server/replicator.go
@@ -271,10 +271,10 @@ func (r *replicator) caughtUp(stop <-chan struct{}, leo int64, req replicationRe
 		r.partition.srv.startGoroutine(func() {
 			select {
 			case <-waiter:
-				r.partition.sendPartitionNotification(req.ReplicaID)
 				r.mu.Lock()
 				r.waiter = nil
 				r.mu.Unlock()
+				r.partition.sendPartitionNotification(req.ReplicaID)
 			case <-stop:
 			}
 		})


### PR DESCRIPTION
Fix a race condition around registering data waiters during replication
when a replica has caught up with the leader. This involved sending the
notification to the replica before unregistering the waiter, which could
cause a subsequent request from the replica from being unable to
register a new waiter since the previous one had not yet been removed.
This race would result in extremely high tail latencies on message
commits.

To fix this, we simply unregister the waiter before sending the
notification to the replica.