### PR TITLE
Fix NATS async error panic and scope all internal subjects to namespace

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/nats-io/nats.go"
-	"github.com/nats-io/nuid"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -216,7 +215,7 @@ func (a *apiServer) Publish(ctx context.Context, req *client.PublishRequest) (
 	}
 
 	if req.AckInbox == "" {
-		req.AckInbox = nuid.Next()
+		req.AckInbox = a.getAckInbox()
 	}
 
 	var (
@@ -246,7 +245,7 @@ func (a *apiServer) Publish(ctx context.Context, req *client.PublishRequest) (
 // Asynchronously publish messages to a stream. This returns a stream which
 // will yield PublishResponses for messages whose AckPolicy is not NONE.
 func (a *apiServer) PublishAsync(stream client.API_PublishAsyncServer) error {
-	ackInbox := nuid.Next()
+	ackInbox := a.getAckInbox()
 	sub, err := a.ncPublishes.Subscribe(ackInbox, func(m *nats.Msg) {
 		ack, err := proto.UnmarshalAck(m.Data)
 		if err != nil {
@@ -279,7 +278,7 @@ func (a *apiServer) PublishToSubject(ctx context.Context, req *client.PublishToS
 	a.logger.Debugf("api: PublishToSubject [subject=%s]", req.Subject)
 
 	if req.AckInbox == "" {
-		req.AckInbox = nuid.Next()
+		req.AckInbox = a.getAckInbox()
 	}
 
 	var (

--- a/server/metadata.go
+++ b/server/metadata.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nats-io/nats.go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -200,7 +199,7 @@ func (m *metadataAPI) fetchBrokerInfo(ctx context.Context, numPeers int) ([]*cli
 	}
 
 	// Create subscription to receive responses on.
-	inbox := nats.NewInbox()
+	inbox := m.getMetadataReplyInbox()
 	sub, err := m.ncRaft.SubscribeSync(inbox)
 	if err != nil {
 		return nil, status.New(codes.Internal, err.Error())

--- a/server/raft.go
+++ b/server/raft.go
@@ -304,7 +304,7 @@ func (s *Server) detectBootstrapMisconfig() {
 			}
 		}
 	})
-	inbox := nats.NewInbox()
+	inbox := fmt.Sprintf("%s.bootstrap.reply", s.baseMetadataRaftSubject())
 	s.ncRaft.Subscribe(inbox, func(m *nats.Msg) {
 		s.logger.Fatalf("Server %s was also started with raft.bootstrap.seed", string(m.Data))
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -705,8 +705,19 @@ func (s *Server) natsClosedHandler(nc *nats.Conn) {
 // natsErrorHandler fires when there is an asynchronous error on the NATS
 // connection.
 func (s *Server) natsErrorHandler(nc *nats.Conn, sub *nats.Subscription, err error) {
-	s.logger.Errorf("Asynchronous error on connection %s, subject %s: %s",
-		nc.Opts.Name, sub.Subject, err)
+	var (
+		msg    = "Asynchronous error on NATS connection"
+		prefix = " "
+	)
+	if nc != nil {
+		msg += fmt.Sprintf(" %s", nc.Opts.Name)
+		prefix = ", "
+	}
+	if sub != nil {
+		msg += fmt.Sprintf("%ssubject %s", prefix, sub.Subject)
+	}
+	msg += fmt.Sprintf(": %s", err)
+	s.logger.Errorf(msg)
 }
 
 // handleServerInfoRequest is a NATS handler used to process requests for

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nuid"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -816,11 +817,23 @@ func (s *Server) getPartitionStatusInbox(id string) string {
 	return fmt.Sprintf("%s.status.%s", s.baseMetadataRaftSubject(), id)
 }
 
+// getMetadataReplyInbox returns a random NATS subject to use for metadata
+// responses scoped to the cluster namespace.
+func (s *Server) getMetadataReplyInbox() string {
+	return fmt.Sprintf("%s.fetch.%s", s.baseMetadataRaftSubject(), nuid.Next())
+}
+
 // getPartitionNotificationInbox returns the NATS subject used for leaders to
 // indicate new data is available on a partition for a follower to replicate if
 // the follower is idle.
 func (s *Server) getPartitionNotificationInbox(id string) string {
 	return fmt.Sprintf("%s.notify.%s", s.config.Clustering.Namespace, id)
+}
+
+// getAckInbox returns a random NATS subject to use for publish acks scoped to
+// the cluster namespace.
+func (s *Server) getAckInbox() string {
+	return fmt.Sprintf("%s.ack.%s", s.config.Clustering.Namespace, nuid.Next())
 }
 
 // getActivityStreamSubject returns the NATS subject used for publishing


### PR DESCRIPTION
This fixes a nil pointer which caused the server to panic in the event of an async error on a NATS connection.

Also remove all uses of non-scoped NATS subjects, e.g. _INBOX.* and nuids. There were a couple cases where subjects were not being scoped, namely publish acks and some internal metadata subjects. This makes it easier for users who have authorization rules around subjects configured on NATS.