### PR TITLE
Preempt replication request loop earlier

### DIFF
--- a/server/partition.go
+++ b/server/partition.go
@@ -825,6 +825,14 @@ func (p *partition) replicationRequestLoop(leader string, epoch uint64, stop <-c
 		if err != nil {
 			p.srv.logger.Errorf(
 				"Error sending replication request for partition %s: %v", p, err)
+
+			// Check if the loop has since been stopped. This is possible, for
+			// example, if another leader was since elected.
+			select {
+			case <-stop:
+				return
+			default:
+			}
 		} else {
 			leaderLastSeen = time.Now()
 		}


### PR DESCRIPTION
Check if the replication request loop was stopped after a replication
error in order to avoid spurious leader reports. This is mainly to
handle the case of a leader failover causing additional error logs which
are benign but can be confusing.