### PR TITLE
Maintain ISR across partition pauses

### DIFF
--- a/server/partition.go
+++ b/server/partition.go
@@ -1070,6 +1070,12 @@ func (p *partition) RemoveFromISR(replica string) error {
 	}
 	delete(p.isr, replica)
 
+	// Also update the ISR on the protobuf so this state is persisted.
+	p.Isr = make([]string, 0, len(p.isr))
+	for replica := range p.isr {
+		p.Isr = append(p.Isr, replica)
+	}
+
 	// Check if ISR went below minimum ISR size. This is important for
 	// operators to be aware of.
 	var (
@@ -1102,6 +1108,12 @@ func (p *partition) AddToISR(rep string) error {
 		return fmt.Errorf("%s not a replica", rep)
 	}
 	p.isr[rep] = &replica{offset: -1}
+
+	// Also update the ISR on the protobuf so this state is persisted.
+	p.Isr = make([]string, 0, len(p.isr))
+	for replica := range p.isr {
+		p.Isr = append(p.Isr, replica)
+	}
 
 	// Check if ISR recovered from being below the minimum ISR size.
 	var (

--- a/server/replicator_test.go
+++ b/server/replicator_test.go
@@ -51,7 +51,10 @@ LOOP:
 }
 
 func waitForISR(t *testing.T, timeout time.Duration, name string, partitionID int32, isrSize int, servers ...*Server) {
-	deadline := time.Now().Add(timeout)
+	var (
+		actualSize int
+		deadline   = time.Now().Add(timeout)
+	)
 LOOP:
 	for time.Now().Before(deadline) {
 		for _, s := range servers {
@@ -60,14 +63,16 @@ LOOP:
 				time.Sleep(15 * time.Millisecond)
 				continue LOOP
 			}
-			if partition.ISRSize() != isrSize {
+			actualSize = partition.ISRSize()
+			if actualSize != isrSize {
 				time.Sleep(15 * time.Millisecond)
 				continue LOOP
 			}
 		}
 		return
 	}
-	stackFatalf(t, "Cluster did not reach ISR size %d for [name=%s, partition=%d]", isrSize, name, partitionID)
+	stackFatalf(t, "Cluster did not reach ISR size %d for [name=%s, partition=%d], actual ISR size is %d",
+		isrSize, name, partitionID, actualSize)
 }
 
 func stopFollowing(t *testing.T, p *partition) {


### PR DESCRIPTION
Ensure if a partition ISR changes and the partition is paused and
subsequently resumed that the ISR matches the state when the partition
was paused.

This fixes #236.