### PR TITLE
Add paused status to partition metadata

### DIFF
--- a/server/metadata.go
+++ b/server/metadata.go
@@ -264,6 +264,7 @@ func (m *metadataAPI) createMetadataResponse(streams []string) *client.FetchMeta
 					Leader:   leader,
 					Replicas: partition.GetReplicas(),
 					Isr:      partition.GetISR(),
+					Paused:   partition.GetPaused(),
 				}
 			}
 			metadata[i] = &client.StreamMetadata{


### PR DESCRIPTION
This adds a `paused` field to every partition's metadata, representing the partition's paused status.