### PR TITLE
Docker image as non root and push k8s image to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,33 @@ jobs:
             docker push "liftbridge/liftbridge:${VERSION}"
             docker push 'liftbridge/liftbridge:latest'
 
+  # Build and publish release k8s Docker image
+  build-and-push-release-k8s-image:
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Set image version
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+                echo "export VERSION='${CIRCLE_TAG}-k8s'" >> $BASH_ENV
+            else
+                echo "export VERSION='${CIRCLE_SHA1}-k8s'" >> $BASH_ENV
+            fi
+      - run:
+          name: Build image
+          command: |
+            docker build -t "liftbridge/liftbridge:${VERSION}" -f k8s/Dockerfile.k8s .
+            docker tag "liftbridge/liftbridge:${VERSION}" 'liftbridge/liftbridge:latest-k8s'
+      - run:
+          name: Publish image
+          command: |
+            echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker push "liftbridge/liftbridge:${VERSION}"
+            docker push 'liftbridge/liftbridge:latest-k8s'
+
   # Create GitHub release and upload artifacts
   release:
     docker:
@@ -151,6 +178,13 @@ workflows:
             tags:
               only: /^v.*/
       - build-and-push-release-image:
+          context: docker-push
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+      - build-and-push-release-k8s-image:
           context: docker-push
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,21 +104,21 @@ jobs:
           name: Set image version
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
-                echo "export VERSION='${CIRCLE_TAG}-k8s'" >> $BASH_ENV
+                echo "export VERSION='${CIRCLE_TAG}'" >> $BASH_ENV
             else
-                echo "export VERSION='${CIRCLE_SHA1}-k8s'" >> $BASH_ENV
+                echo "export VERSION='${CIRCLE_SHA1}'" >> $BASH_ENV
             fi
       - run:
           name: Build image
           command: |
-            docker build -t "liftbridge/liftbridge:${VERSION}" -f k8s/Dockerfile.k8s .
-            docker tag "liftbridge/liftbridge:${VERSION}" 'liftbridge/liftbridge:latest-k8s'
+            docker build -t "liftbridge/liftbridge-k8s:${VERSION}" -f k8s/Dockerfile.k8s .
+            docker tag "liftbridge/liftbridge-k8s:${VERSION}" 'liftbridge/liftbridge-k8s:latest'
       - run:
           name: Publish image
           command: |
             echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push "liftbridge/liftbridge:${VERSION}"
-            docker push 'liftbridge/liftbridge:latest-k8s'
+            docker push "liftbridge/liftbridge-k8s:${VERSION}"
+            docker push 'liftbridge/liftbridge-k8s:latest'
 
   # Create GitHub release and upload artifacts
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ ENV GOOS linux
 RUN go build -mod=readonly -o liftbridge
 
 FROM alpine:latest
-COPY --from=build-base /go/src/github.com/liftbridge-io/liftbridge/liftbridge /usr/local/bin/liftbridge
+RUN addgroup -g 1001 -S liftbridge && adduser -u 1001 -S liftbridge -G liftbridge
+COPY --chown=liftbridge:liftbridge --from=build-base /go/src/github.com/liftbridge-io/liftbridge/liftbridge /usr/local/bin/liftbridge
 EXPOSE 9292
 VOLUME "/tmp/liftbridge/liftbridge-default"
 ENTRYPOINT ["liftbridge"]
+USER liftbridge

--- a/k8s/Dockerfile.k8s
+++ b/k8s/Dockerfile.k8s
@@ -24,7 +24,9 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 
 FROM alpine:latest
 RUN apk update && apk add --no-cache bash
-COPY --from=build-base /workspace/liftbridge /usr/local/bin/liftbridge
-COPY --from=build-base /bin/grpc_health_probe /bin/grpc_health_probe
+RUN addgroup -g 1001 -S liftbridge && adduser -u 1001 -S liftbridge -G liftbridge
+COPY --chown=liftbridge:liftbridge --from=build-base /workspace/liftbridge /usr/local/bin/liftbridge
+COPY --chown=liftbridge:liftbridge --from=build-base /bin/grpc_health_probe /bin/grpc_health_probe
 COPY k8s/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+USER liftbridge


### PR DESCRIPTION
We briefly discussed this on the community slack a couple weeks ago, let me know what you think :) 
Not sure if you'd rather have the k8s image pushed to a different repo instead of a tag suffix.