### PR TITLE
Fix bug related to HW and empty log

### DIFF
--- a/server/commitlog/reader.go
+++ b/server/commitlog/reader.go
@@ -346,7 +346,7 @@ func (l *commitLog) newReaderCommitted(offset int64) (contextReader, error) {
 
 	// If offset exceeds HW, wait for the next message. This also covers the
 	// case when the log is empty.
-	if offset > hw {
+	if offset > hw || l.OldestOffset() == -1 {
 		return &committedReader{
 			cl:    l,
 			seg:   nil,


### PR DESCRIPTION
Fix a bug where retention limits are applied to a log past a HW. This
caused subscribe calls to return an "entry not found" error.

This fixes #28.