### PR TITLE
Allow using an automatically assigned connection port

### DIFF
--- a/server/metadata.go
+++ b/server/metadata.go
@@ -209,7 +209,7 @@ func (m *metadataAPI) brokerCache(serverIDs map[string]struct{}) ([]*client.Brok
 // argument is the expected number of peers to get a response from.
 func (m *metadataAPI) fetchBrokerInfo(ctx context.Context, numPeers int) ([]*client.Broker, *status.Status) {
 	// Add ourselves.
-	connectionAddress := m.config.GetConnectionAddress()
+	connectionAddress := m.getConnectionAddress()
 	brokers := []*client.Broker{{
 		Id:   m.config.Clustering.ServerID,
 		Host: connectionAddress.Host,

--- a/server/server.go
+++ b/server/server.go
@@ -264,12 +264,7 @@ func (s *Server) IsRunning() bool {
 func (s *Server) GetListenPort() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	if s.listener == nil {
-		return 0
-	}
-
-	return s.listener.Addr().(*net.TCPAddr).Port
+	return s.port
 }
 
 // recoverAndPersistState recovers any existing server metadata state from disk


### PR DESCRIPTION
Liftbridge allows setting 0 as a listen port. In that case the operating system will provide a free port to listen to. This prevents any port conflict between processes and/or during testing.

Liftbridge also uses a connection port that is sent to clients. Configuring it to listen on port 0 means that the clients will also receive 0 as a port to connect to, which will fail.

This PR fixes this issue by making the server send the port it is currently listening to in case the configured connection port is 0.