### PR TITLE
Correct FetchPartitionMetadata debug log

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -237,7 +237,7 @@ func (a *apiServer) FetchMetadata(ctx context.Context, req *client.FetchMetadata
 // newest offset for a partition.
 func (a *apiServer) FetchPartitionMetadata(ctx context.Context, req *client.FetchPartitionMetadataRequest) (
 	*client.FetchPartitionMetadataResponse, error) {
-	a.logger.Debug("api: FetchPartitionMetadata [stream=%s, partition=%s]", req.Stream, req.Partition)
+	a.logger.Debugf("api: FetchPartitionMetadata [stream=%s, partition=%s]", req.Stream, req.Partition)
 
 	resp, err := a.metadata.FetchPartitionMetadata(ctx, req)
 	if err != nil {


### PR DESCRIPTION
Noticed this small mistake while trying liftbridge out locally:

```
msg="api: FetchPartitionMetadata [stream=%s, partition=%s]test0"
```