### PR TITLE
Remove unused Dockerfile directives

### DIFF
--- a/docker/dev-standalone/Dockerfile
+++ b/docker/dev-standalone/Dockerfile
@@ -1,18 +1,11 @@
-FROM golang:1.13-alpine as build-base
-RUN apk update && apk upgrade && \
-    apk add --no-cache bash git openssh make
-
-WORKDIR /workspace
+FROM golang:1.14-alpine as build-base
 
 ENV GO111MODULE on
 RUN go get github.com/liftbridge-io/liftbridge
 RUN go get github.com/nats-io/nats-server/v2
 
-COPY docker/dev-standalone/ docker/dev-standalone/
-COPY liftbridge-dev liftbridge-dev
-
 FROM alpine:latest
-COPY --from=build-base /workspace/liftbridge-dev /usr/local/bin/liftbridge
+COPY --from=build-base /go/bin/liftbridge /usr/local/bin/liftbridge
 COPY --from=build-base /go/bin/nats-server /usr/local/bin/nats-server
 
 EXPOSE 9292 4222 8222 6222

--- a/docker/dev-standalone/README.md
+++ b/docker/dev-standalone/README.md
@@ -44,7 +44,6 @@ If you want to advertise a docker host that is not localhost:
 docker run -d --add-host registry:0.0.0.0 --name=liftbridge-main -p 4222:4222 -p 9292:9292 -p 8222:8222 -p 6222:6222 -eLIFTBRIDGE_HOST=registry liftbridge/standalone-dev
 ```
 
-
 ### Volume
 
 Optionally you can specify the mount point with:
@@ -98,6 +97,5 @@ cluster {
 Go to the root directory of the Liftbridge source code and run:
 
 ```
-$ make build-dev
-$ docker build -t liftbridge/standalone-dev -f docker/dev-image/Dockerfile .
+$ docker build -t liftbridge/standalone-dev -f docker/dev-standalone/Dockerfile .
 ```


### PR DESCRIPTION
Hey,

Noticed that the dev-standalone Dockerfile was doing some unusual things (both building liftbridge from source using go get and copying the pre-build binary from filesystem). Have reduced this to just building using go get. I updated the version of go in the Dockerfile too, to match what's in go.mod