### PR TITLE
Fix loopback client race

### DIFF
--- a/server/activity.go
+++ b/server/activity.go
@@ -84,7 +84,9 @@ func (a *activityManager) BecomeFollower() error {
 		return nil
 	}
 
-	close(a.leadershipLostCh)
+	if a.leadershipLostCh != nil {
+		close(a.leadershipLostCh)
+	}
 	return nil
 }
 

--- a/server/activity.go
+++ b/server/activity.go
@@ -2,14 +2,14 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/raft"
-	lift "github.com/liftbridge-io/go-liftbridge/v2"
 	client "github.com/liftbridge-io/liftbridge-api/go"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	proto "github.com/liftbridge-io/liftbridge/server/protocol"
 )
@@ -209,12 +209,12 @@ func (a *activityManager) handleRaftLog(l *raft.Log) error {
 // createActivityStream creates the activity stream and connects a local client
 // that will be subscribed to it.
 func (a *activityManager) createActivityStream() error {
-	err := a.getLoopbackClient().CreateStream(context.Background(),
-		a.getActivityStreamSubject(),
-		activityStream,
-		lift.MaxReplication(),
-	)
-	if err != nil && err != lift.ErrStreamExists {
+	_, err := a.api.CreateStream(context.Background(), &client.CreateStreamRequest{
+		Subject:           a.getActivityStreamSubject(),
+		Name:              activityStream,
+		ReplicationFactor: -1,
+	})
+	if err != nil && status.Convert(err).Code() != codes.AlreadyExists {
 		return errors.Wrap(err, "failed to create an activity stream")
 	}
 
@@ -231,25 +231,11 @@ func (a *activityManager) publishActivityEvent(event *client.ActivityStreamEvent
 	ctx, cancel := context.WithTimeout(context.Background(), a.config.ActivityStream.PublishTimeout)
 	defer cancel()
 
-	var messageOption lift.MessageOption
-	ackPolicy := a.config.ActivityStream.PublishAckPolicy
-	switch ackPolicy {
-	case client.AckPolicy_LEADER:
-		messageOption = lift.AckPolicyLeader()
-	case client.AckPolicy_ALL:
-		messageOption = lift.AckPolicyAll()
-	case client.AckPolicy_NONE:
-		messageOption = lift.AckPolicyNone()
-	default:
-		panic(fmt.Sprintf("Unknown ack policy: %v", ackPolicy))
-	}
-
-	_, err = a.getLoopbackClient().Publish(
-		ctx,
-		activityStream,
-		data,
-		messageOption,
-	)
+	_, err = a.api.Publish(ctx, &client.PublishRequest{
+		Value:     data,
+		Stream:    activityStream,
+		AckPolicy: a.config.ActivityStream.PublishAckPolicy,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to publish event to stream")
 	}

--- a/server/api.go
+++ b/server/api.go
@@ -166,6 +166,39 @@ func (a *apiServer) SetStreamReadonly(ctx context.Context, req *client.SetStream
 // messages when it reaches the end of the partition. Use the request context
 // to close the subscription.
 func (a *apiServer) Subscribe(req *client.SubscribeRequest, out client.API_SubscribeServer) error {
+	msgC, errC, cancel, err := a.SubscribeInternal(out.Context(), req)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	// Send an empty message which signals the subscription was successfully
+	// created.
+	if err := out.Send(&client.Message{}); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-out.Context().Done():
+			return nil
+		case m := <-msgC:
+			if err := out.Send(m); err != nil {
+				return err
+			}
+		case err := <-errC:
+			return err.Err()
+		}
+	}
+}
+
+// Subscribe creates an ephemeral subscription for the given stream partition.
+// It begins to receive messages starting at the given offset and waits for new
+// messages when it reaches the end of the partition. Use the request context
+// to close the subscription. This is a non-gRPC API for internal use.
+func (a *apiServer) SubscribeInternal(ctx context.Context, req *client.SubscribeRequest) (
+	<-chan *client.Message, <-chan *status.Status, func(), error) {
+
 	a.logger.Debugf("api: Subscribe [stream=%s, partition=%d, start=%s, offset=%d, timestamp=%d]",
 		req.Stream, req.Partition, req.StartPosition, req.StartOffset, req.StartTimestamp)
 
@@ -174,7 +207,7 @@ func (a *apiServer) Subscribe(req *client.SubscribeRequest, out client.API_Subsc
 		a.logger.Errorf("api: Failed to subscribe to partition "+
 			"[stream=%s, partition=%d]: no such partition",
 			req.Stream, req.Partition)
-		return status.Error(codes.NotFound, "No such partition")
+		return nil, nil, nil, status.Error(codes.NotFound, "No such partition")
 	}
 
 	leader, _ := partition.GetLeader()
@@ -183,40 +216,18 @@ func (a *apiServer) Subscribe(req *client.SubscribeRequest, out client.API_Subsc
 			a.logger.Info("api: Accepting subscription to partition %s: server not stream leader", partition)
 		} else {
 			a.logger.Errorf("api: Failed to subscribe to partition %s: server not stream leader", partition)
-			return status.Error(codes.FailedPrecondition, "Server not partition leader")
+			return nil, nil, nil, status.Error(codes.FailedPrecondition, "Server not partition leader")
 		}
 	}
 
 	cancel := make(chan struct{})
-	defer close(cancel)
-	ch, errCh, err := a.subscribe(out.Context(), partition, req, cancel)
+	ch, errCh, err := a.subscribe(ctx, partition, req, cancel)
 	if err != nil {
 		a.logger.Errorf("api: Failed to subscribe to partition %s: %v", partition, err.Err())
-		return err.Err()
+		return nil, nil, nil, err.Err()
 	}
 
-	// Send an empty message which signals the subscription was successfully
-	// created.
-	if err := out.Send(&client.Message{}); err != nil {
-		return err
-	}
-
-	// Update the active subscriber count.
-	partition.IncreaseSubscriberCount()
-	defer partition.DecreaseSubscriberCount()
-
-	for {
-		select {
-		case <-out.Context().Done():
-			return nil
-		case m := <-ch:
-			if err := out.Send(m); err != nil {
-				return err
-			}
-		case err := <-errCh:
-			return err.Err()
-		}
-	}
+	return ch, errCh, func() { close(cancel) }, nil
 }
 
 // FetchMetadata retrieves the latest cluster metadata, including stream broker
@@ -681,6 +692,10 @@ func (a *apiServer) subscribe(ctx context.Context, partition *partition,
 	}
 
 	a.startGoroutine(func() {
+		// Update the active subscriber count.
+		partition.IncreaseSubscriberCount()
+		defer partition.DecreaseSubscriberCount()
+
 		headersBuf := make([]byte, 28)
 		for {
 			// TODO: this could be more efficient.

--- a/server/server.go
+++ b/server/server.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/raft"
-	lift "github.com/liftbridge-io/go-liftbridge/v2"
 	client "github.com/liftbridge-io/liftbridge-api/go"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nuid"
@@ -55,7 +54,8 @@ type Server struct {
 	ncPublishes        *nats.Conn
 	logger             logger.Logger
 	loggerOut          io.Writer
-	api                *grpc.Server
+	grpcServer         *grpc.Server
+	api                *apiServer
 	metadata           *metadataAPI
 	shutdownCh         chan struct{}
 	raft               atomic.Value
@@ -66,7 +66,6 @@ type Server struct {
 	shutdown           bool
 	running            bool
 	goroutineWait      sync.WaitGroup
-	client             atomic.Value
 	activity           *activityManager
 	cursors            *cursorManager
 }
@@ -187,10 +186,6 @@ func (s *Server) Start() (err error) {
 		return errors.Wrap(err, "failed to start API server")
 	}
 
-	if err := s.createLoopbackClient(); err != nil {
-		return errors.Wrap(err, "failed to create loopback client")
-	}
-
 	s.startRaftLeadershipLoop()
 	return nil
 }
@@ -208,8 +203,8 @@ func (s *Server) Stop() error {
 	s.logger.Info("Shutting down...")
 
 	close(s.shutdownCh)
-	if s.api != nil {
-		s.api.Stop()
+	if s.grpcServer != nil {
+		s.grpcServer.Stop()
 	}
 
 	if s.listener != nil {
@@ -225,13 +220,6 @@ func (s *Server) Stop() error {
 
 	if raft := s.getRaft(); raft != nil {
 		if err := raft.shutdown(); err != nil {
-			s.mu.Unlock()
-			return err
-		}
-	}
-
-	if client := s.getLoopbackClient(); client != nil {
-		if err := client.Close(); err != nil {
 			s.mu.Unlock()
 			return err
 		}
@@ -413,18 +401,19 @@ func (s *Server) startAPIServer() error {
 		opts = append(opts, grpc.Creds(creds))
 	}
 
-	api := grpc.NewServer(opts...)
-	s.api = api
-	client.RegisterAPIServer(api, &apiServer{s})
+	grpcServer := grpc.NewServer(opts...)
+	s.grpcServer = grpcServer
+	s.api = &apiServer{s}
+	client.RegisterAPIServer(grpcServer, s.api)
 
-	health.Register(api)
+	health.Register(grpcServer)
 
 	s.mu.Lock()
 	s.running = true
 	s.mu.Unlock()
 	s.startGoroutine(func() {
 		health.SetServing()
-		err := api.Serve(s.listener)
+		err := grpcServer.Serve(s.listener)
 		s.mu.Lock()
 		s.running = false
 		s.mu.Unlock()
@@ -439,51 +428,6 @@ func (s *Server) startAPIServer() error {
 	})
 
 	return nil
-}
-
-// createLoopbackClient creates a Liftbridge client connected to this server's
-// loopback address used for internal purposes.
-func (s *Server) createLoopbackClient() error {
-	var (
-		addr     = s.listener.Addr()
-		deadline = time.Now().Add(10 * time.Second)
-		conn     net.Conn
-		err      error
-	)
-	for time.Now().Before(deadline) {
-		conn, err = net.Dial("tcp", addr.String())
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-	if conn == nil {
-		return err
-	}
-	if err := conn.Close(); err != nil {
-		return err
-	}
-	opts := []lift.ClientOption{}
-	if s.config.TLSCert != "" {
-		// Skip TLS verification since we're just connecting to loopback.
-		tlsConfig := &tls.Config{InsecureSkipVerify: true}
-		opts = append(opts, lift.TLSConfig(tlsConfig))
-	}
-	client, err := lift.Connect([]string{addr.String()}, opts...)
-	if err != nil {
-		return err
-	}
-	s.client.Store(client)
-	return nil
-}
-
-// getLoopbackClient returns the Liftbridge client connected to this server.
-func (s *Server) getLoopbackClient() lift.Client {
-	client := s.client.Load()
-	if client == nil {
-		return nil
-	}
-	return client.(lift.Client)
 }
 
 // createNATSConn creates a new NATS connection with the given name.


### PR DESCRIPTION
Fix #283 where server can become metadata leader before a loopback
client has been created. This replaces the loopback client with direct
API calls.