### PR TITLE
Change dev-standalone host default to 0.0.0.0

### DIFF
--- a/docker/dev-standalone/liftbridge.yaml
+++ b/docker/dev-standalone/liftbridge.yaml
@@ -1,2 +1,2 @@
 ---
-host: localhost
+host: 0.0.0.0


### PR DESCRIPTION
Use 0.0.0.0 as the default rather than localhost so that clients can
connect by default.

This fixes https://github.com/liftbridge-io/go-liftbridge/issues/94.