### PR TITLE
Get master for dev-standalone docker image

### DIFF
--- a/docker/dev-standalone/Dockerfile
+++ b/docker/dev-standalone/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.14-alpine as build-base
 
 ENV GO111MODULE on
-RUN go get github.com/liftbridge-io/liftbridge
+RUN go get github.com/liftbridge-io/liftbridge@master
 RUN go get github.com/nats-io/nats-server/v2
 
 FROM alpine:latest


### PR DESCRIPTION
Realised I introduced a bug with #281 

Go get by default fetches the latest tagged version (v1.3.0), whereas here we want the tip of master.

I think we'll always want to fetch master in the current build pipeline, but I could set this up as a docker build arg if it wants to be variable?