### PR TITLE
Embedded NATS

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -24,7 +24,7 @@ USAGE:
    liftbridge [global options] command [command options] [arguments...]
 
 VERSION:
-   v1.4.1
+   v1.5.0
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -34,6 +34,8 @@ GLOBAL OPTIONS:
    --server-id value, --id value               ID of the server in the cluster if there is no stored ID (default: random ID)
    --namespace value, --ns value               cluster namespace (default: "liftbridge-default")
    --nats-servers ADDR[,ADDR], -n ADDR[,ADDR]  connect to NATS cluster at ADDR[,ADDR] (default: "nats://127.0.0.1:4222")
+   --embedded-nats, -e                         run a NATS server embedded in this process
+   --embedded-nats-config FILE, --nc FILE      load configuration for embedded NATS server from FILE
    --data-dir DIR, -d DIR                      store data in DIR (default: "/tmp/liftbridge/<namespace>")
    --port value, -p value                      port to bind to (default: 9292)
    --tls-cert value                            server certificate file
@@ -101,7 +103,7 @@ clustering:
   replica.max.lag.time: 20s
 ```
 
-## Overriding configuration settings with environment variables
+## Overriding Configuration Settings with Environment Variables
 
 For configuration set in the configuration file the value can be overridden
 with environment variables prefixed with `LIFTBRIDGE_`. The key must exist in
@@ -125,15 +127,15 @@ the setting in the configuration file and the CLI flag if it exists.
 |:----|:----|:----|:----|:----|:----|
 | listen | | The server listen host/port. This is the host and port the server will bind to. If this is not specified but `host` and `port` are specified, these values will be used. If neither `listen` nor `host`/`port` are specified, the default listen address will be used. | string | 0:0:0:0:9292  | |
 | host | | The server host that is advertised to clients, i.e. the address clients will attempt to connect to based on metadata API responses. If not set, `listen` will be returned to clients. This value may differ from `listen` in situations where the external address differs from the internal address, e.g. when running in a container. If `listen` is not specified, the server will also bind to this host. | string | localhost | |
-| port | port | The server port that is advertised to clients. See `host` for more information on how this behaves. | int | 9292 | |
+| port | port, p | The server port that is advertised to clients. See `host` for more information on how this behaves. | int | 9292 | |
 | tls.key | tls-key | The private key file for server certificate. This must be set in combination with `tls.cert` to enable TLS. | string | |
 | tls.cert | tls-cert | The server certificate file. This must be set in combination with `tls.key` to enable TLS. | string | |
 | tls.client.auth.enabled | tls-client-auth | Enforce client-side authentication via certificate. | bool | false |
 | tls.client.auth.ca | tls-client-auth-ca | The CA certificate file to use when authenticating clients. | string | |
-| logging.level | level | The logging level. | string | info | [debug, info, warn, error] |
+| logging.level | level, l | The logging level. | string | info | [debug, info, warn, error] |
 | logging.recovery | | Log messages resulting from the replay of the Raft log on server recovery. | bool | false | |
 | logging.raft | | Enables logging in the Raft subsystem. | bool | false | |
-| data.dir | data-dir | The directory to store data in. | string | /tmp/liftbridge/namespace | |
+| data.dir | data-dir, d | The directory to store data in. | string | /tmp/liftbridge/namespace | |
 | batch.max.messages | | The maximum number of messages to batch when writing to disk. | int | 1024 |
 | batch.max.time | | The maximum time to wait to batch more messages when writing to disk. | duration | 0 | |
 | metadata.cache.max.age | | The maximum age of cached broker metadata. | duration | 2m | |
@@ -150,12 +152,14 @@ the configuration file.
 
 | Name | Flag | Description | Type | Default | Valid Values |
 |:----|:----|:----|:----|:----|:----|
-| servers | nats-servers | List of NATS hosts to connect to. | list | nats://localhost:4222 | |
+| servers | nats-servers, n | List of NATS hosts to connect to. | list | nats://localhost:4222 | |
 | user | | Username to use to connect to NATS servers. | string | | |
 | password | | Password to use to connect to NATS servers. | string | | |
 | tls.cert | | Path to NATS certificate file. | string | | |
 | tls.key | | Path to NATS key file. | string | | |
 | tls.ca  | | Path to NATS CA Root file. | string | | |
+| embedded | embedded-nats, e | Run a NATS server embedded in the process. | bool | false | |
+| embedded.config | embedded-nats-config, nc | Path to [configuration file](https://docs.nats.io/nats-server/configuration) for embedded NATS server. | string | | |
 
 ### Streams Configuration Settings
 
@@ -184,8 +188,8 @@ the configuration file.
 
 | Name | Flag | Description | Type | Default | Valid Values |
 |:----|:----|:----|:----|:----|:----|
-| server.id | server-id | ID of the server in the cluster. | string | random id | string with no spaces or periods |
-| namespace | namespace | Cluster namespace. | string | liftbridge-default | string with no spaces or periods |
+| server.id | server-id, id | ID of the server in the cluster. | string | random id | string with no spaces or periods |
+| namespace | namespace, ns | Cluster namespace. | string | liftbridge-default | string with no spaces or periods |
 | raft.snapshot.retain | | The number Raft log snapshots to retain on disk. | int | 2 | |
 | raft.snapshot.threshold | | Controls how many outstanding logs there must be before taking a snapshot. This prevents excessive snapshots when a small set of logs can be replayed. | int | 8192 | |
 | raft.cache.size | | The number of Raft logs to hold in memory for quick lookup. | int | 512 | |

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -135,6 +135,7 @@ the setting in the configuration file and the CLI flag if it exists.
 | logging.level | level, l | The logging level. | string | info | [debug, info, warn, error] |
 | logging.recovery | | Log messages resulting from the replay of the Raft log on server recovery. | bool | false | |
 | logging.raft | | Enables logging in the Raft subsystem. | bool | false | |
+| logging.nats | | Enables logging for the embedded NATS server, if enabled (see [`nats.embedded`](#nats-configuration-settings)). | bool | false | |
 | data.dir | data-dir, d | The directory to store data in. | string | /tmp/liftbridge/namespace | |
 | batch.max.messages | | The maximum number of messages to batch when writing to disk. | int | 1024 |
 | batch.max.time | | The maximum time to wait to batch more messages when writing to disk. | duration | 0 | |

--- a/documentation/embedded_nats.md
+++ b/documentation/embedded_nats.md
@@ -1,0 +1,41 @@
+---
+id: embedded-nats
+title: Embedded NATS
+---
+
+Liftbridge relies on [NATS](https://github.com/nats-io/nats-server) for
+intra-cluster communication. By default, it will connect to a NATS server
+running on localhost. The
+[`nats.servers`](./configuration.md#nats-configuration-settings) setting allows
+configuring the NATS server(s) to connect to. However, Liftbridge can also run
+a NATS server embedded in the process, allowing it to run as a complete,
+self-contained system with no external dependencies. The below examples show
+how this can be done.
+
+## Default Configuration
+
+To run an embedded NATS server with the [default configuration](https://docs.nats.io/nats-server/configuration#configuration-properties),
+simply enable the `embedded` setting in the [`nats`](./configuration.md#nats-configuration-settings)
+configuration (or equivalent `--embedded-nats` command-line flag).
+
+```yaml
+nats:
+  embedded: true
+```
+
+This will start a NATS server bound to `0.0.0.0:4222` with default settings.
+
+## Custom Configuration
+
+To run an embedded NATS server with custom configuration, use the
+[`embedded.config`](./configuration.md#nats-configuration-settings) setting (or
+equivalent `--embedded-nats-config` command-line flag) to specify a [NATS
+configuration file](https://docs.nats.io/nats-server/configuration) to use. By
+specifying this, the `embedded` setting will be automatically enabled.
+
+```yaml
+nats:
+  embedded.config: nats.conf
+```
+
+This will start a NATS server using the specified configuration file.

--- a/documentation/embedded_nats.md
+++ b/documentation/embedded_nats.md
@@ -16,11 +16,14 @@ how this can be done.
 
 To run an embedded NATS server with the [default configuration](https://docs.nats.io/nats-server/configuration#configuration-properties),
 simply enable the `embedded` setting in the [`nats`](./configuration.md#nats-configuration-settings)
-configuration (or equivalent `--embedded-nats` command-line flag).
+configuration (or equivalent `--embedded-nats` command-line flag). Set
+`logging.nats` to enable logging for the NATS server.
 
 ```yaml
 nats:
   embedded: true
+
+logging.nats: true
 ```
 
 This will start a NATS server bound to `0.0.0.0:4222` with default settings.
@@ -31,11 +34,14 @@ To run an embedded NATS server with custom configuration, use the
 [`embedded.config`](./configuration.md#nats-configuration-settings) setting (or
 equivalent `--embedded-nats-config` command-line flag) to specify a [NATS
 configuration file](https://docs.nats.io/nats-server/configuration) to use. By
-specifying this, the `embedded` setting will be automatically enabled.
+specifying this, the `embedded` setting will be automatically enabled. Set
+`logging.nats` to enable logging for the NATS server.
 
 ```yaml
 nats:
   embedded.config: nats.conf
+
+logging.nats: true
 ```
 
 This will start a NATS server using the specified configuration file.

--- a/documentation/quick_start.md
+++ b/documentation/quick_start.md
@@ -27,10 +27,13 @@ $ go get github.com/liftbridge-io/liftbridge
 *Liftbridge uses [Go modules](https://github.com/golang/go/wiki/Modules), so
 ensure this is enabled, e.g. `export GO111MODULE=on`.*
 
-Liftbridge currently relies on an externally running
-[NATS server](https://github.com/nats-io/gnatsd). By default, it will connect
-to a NATS server running on localhost. The `--nats-servers` flag allows
-configuring the NATS server(s) to connect to.
+Liftbridge relies on [NATS](https://github.com/nats-io/nats-server) for
+intra-cluster communication. By default, it will connect to a NATS server
+running on localhost. The `--nats-servers` flag allows configuring the NATS
+server(s) to connect to. Liftbridge can also run a NATS server [embedded in the
+process](./embedded_nats.md), allowing it to run as a complete, self-contained
+system with no external dependencies. The `--embedded-nats` flag will start an
+embedded NATS server.
 
 Also note that Liftbridge is clustered by default and relies on Raft for
 coordination. This means a cluster of three or more servers is normally run
@@ -42,14 +45,16 @@ server that can begin handling requests. **Use this flag with caution as it shou
 only be set on one server when bootstrapping a cluster.**
 
 ```shell
-$ liftbridge --raft-bootstrap-seed
-INFO[2020-10-15 14:29:50] Liftbridge Version:        v1.4.1
-INFO[2020-10-15 14:29:50] Server ID:                 4nbhBr66WnRsy0I5oKF9bo
-INFO[2020-10-15 14:29:50] Namespace:                 liftbridge-default
-INFO[2020-10-15 14:29:50] Default Retention Policy:  [Age: 1 week, Compact: false]
-INFO[2020-10-15 14:29:50] Default Partition Pausing: disabled
-INFO[2020-10-15 14:29:50] Starting server on 0.0.0.0:9292...
-INFO[2020-10-15 14:29:51] Server became metadata leader, performing leader promotion actions
+$ liftbridge --raft-bootstrap-seed --embedded-nats
+INFO[2020-12-29 13:19:33] Liftbridge Version:        v1.5.0
+INFO[2020-12-29 13:19:33] Server ID:                 m6nxFIddI395AaQABIQqNL
+INFO[2020-12-29 13:19:33] Namespace:                 liftbridge-default
+INFO[2020-12-29 13:19:33] NATS Servers:              [nats://127.0.0.1:4222]
+INFO[2020-12-29 13:19:33] Default Retention Policy:  [Age: 1 week, Compact: false]
+INFO[2020-12-29 13:19:33] Default Partition Pausing: disabled
+INFO[2020-12-29 13:19:33] Starting embedded NATS server on 0.0.0.0:4222
+INFO[2020-12-29 13:19:33] Starting Liftbridge server on 0.0.0.0:9292...
+INFO[2020-12-29 13:19:34] Server became metadata leader, performing leader promotion actions
 ```
 
 Once a leader has been elected, other servers will automatically join the cluster.
@@ -57,12 +62,13 @@ We set the `--data-dir` and `--port` flags to avoid clobbering the first server.
 
 ```shell
 $ liftbridge --data-dir /tmp/liftbridge/server-2 --port=9293
-INFO[2020-10-15 14:30:48] Liftbridge Version:        v1.4.1
-INFO[2020-10-15 14:30:48] Server ID:                 lbW05esZTab3guEwcmWD9M
-INFO[2020-10-15 14:30:48] Namespace:                 liftbridge-default
-INFO[2020-10-15 14:30:48] Default Retention Policy:  [Age: 1 week, Compact: false]
-INFO[2020-10-15 14:30:48] Default Partition Pausing: disabled
-INFO[2020-10-15 14:30:48] Starting server on 0.0.0.0:9293...
+INFO[2020-12-29 13:21:09] Liftbridge Version:        v1.5.0
+INFO[2020-12-29 13:21:09] Server ID:                 8mTiXh8VSFFBB8kIK0IOGU
+INFO[2020-12-29 13:21:09] Namespace:                 liftbridge-default
+INFO[2020-12-29 13:21:09] NATS Servers:              [nats://127.0.0.1:4222]
+INFO[2020-12-29 13:21:09] Default Retention Policy:  [Age: 1 week, Compact: false]
+INFO[2020-12-29 13:21:09] Default Partition Pausing: disabled
+INFO[2020-12-29 13:21:09] Starting Liftbridge server on 0.0.0.0:9293...
 ```
 
 We can also bootstrap a cluster by providing the explicit cluster configuration.

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -89,7 +89,7 @@ Provide an API that exposes monitoring information and metrics about the server
 to better support Liftbridge operations. This paves the way for future
 monitoring and observability integrations.
 
-### Embedded NATS Server ([#19](https://github.com/liftbridge-io/liftbridge/issues/19))
+### ~~Embedded NATS Server ([#19](https://github.com/liftbridge-io/liftbridge/issues/19))~~
 
 Allow the Liftbridge server to run an embedded instance of NATS rather than
 relying on an external NATS server. This allows Liftbridge to run as a fully

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,7 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09
-	github.com/nats-io/jwt v1.0.1 // indirect
-	github.com/nats-io/nats-server/v2 v2.1.4
+	github.com/nats-io/nats-server/v2 v2.1.9
 	github.com/nats-io/nats.go v1.10.0
 	github.com/nats-io/nkeys v0.2.0 // indirect
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -231,10 +231,12 @@ github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09 h1:DXR0VtCesBD2ss
 github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09/go.mod h1:1rLVY/DWf3U6vSZgH16S7pymfrhK2lcUlXjgGglw/lY=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
-github.com/nats-io/jwt v1.0.1 h1:71ivoESdfT2K/qDiw5YwX/3W9/dR7c+m83xiGOj/EZ4=
-github.com/nats-io/jwt v1.0.1/go.mod h1:n3cvmLfBfnpV4JJRN7lRYCyZnw48ksGsbThGXEk4w9M=
+github.com/nats-io/jwt v1.1.0 h1:+vOlgtM0ZsF46GbmUoadq0/2rChNS45gtxHEa3H1gqM=
+github.com/nats-io/jwt v1.1.0/go.mod h1:n3cvmLfBfnpV4JJRN7lRYCyZnw48ksGsbThGXEk4w9M=
 github.com/nats-io/nats-server/v2 v2.1.4 h1:BILRnsJ2Yb/fefiFbBWADpViGF69uh4sxe8poVDQ06g=
 github.com/nats-io/nats-server/v2 v2.1.4/go.mod h1:Jw1Z28soD/QasIA2uWjXyM9El1jly3YwyFOuR8tH1rg=
+github.com/nats-io/nats-server/v2 v2.1.9 h1:Sxr2zpaapgpBT9ElTxTVe62W+qjnhPcKY/8W5cnA/Qk=
+github.com/nats-io/nats-server/v2 v2.1.9/go.mod h1:9qVyoewoYXzG1ME9ox0HwkkzyYvnlBDugfR4Gg/8uHU=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nats.go v1.9.2/go.mod h1:AjGArbfyR50+afOUotNX2Xs5SYHf+CoOa5HH1eEl2HE=
 github.com/nats-io/nats.go v1.10.0 h1:L8qnKaofSfNFbXg0C5F71LdjPRnmQwSsA4ukmkt1TvY=

--- a/main.go
+++ b/main.go
@@ -89,6 +89,13 @@ func overrideFromFlags(c *cli.Context, config *server.Config) error {
 		}
 		config.NATS.Servers = natsServers
 	}
+	if c.IsSet("embedded-nats") {
+		config.EmbeddedNATS = true
+	}
+	if c.IsSet("embedded-nats-config") {
+		config.EmbeddedNATS = true
+		config.EmbeddedNATSConfig = c.String("embedded-nats-config")
+	}
 	return nil
 }
 
@@ -113,6 +120,14 @@ func getFlags() []cli.Flag {
 			// NOTE: cannot use Value here as urfave/cli has another bug
 			// where it does not replace this value with the specified values but appends them:-(
 			// Value: &cli.StringSlice{nats.DefaultURL},
+		},
+		cli.BoolFlag{
+			Name:  "embedded-nats, e",
+			Usage: "run a NATS server embedded in this process",
+		},
+		cli.StringFlag{
+			Name:  "embedded-nats-config, nc",
+			Usage: "load configuration for embedded NATS server from `FILE`",
 		},
 		cli.StringFlag{
 			Name:  "data-dir, d",

--- a/server/config.go
+++ b/server/config.go
@@ -65,6 +65,7 @@ const (
 	configLoggingLevel    = "logging.level"
 	configLoggingRecovery = "logging.recovery"
 	configLoggingRaft     = "logging.raft"
+	configLoggingNATS     = "logging.nats"
 
 	configBatchMaxMessages = "batch.max.messages"
 	configBatchMaxTime     = "batch.max.time"
@@ -125,6 +126,7 @@ var configKeys = map[string]struct{}{
 	configLoggingLevel:                         {},
 	configLoggingRecovery:                      {},
 	configLoggingRaft:                          {},
+	configLoggingNATS:                          {},
 	configBatchMaxMessages:                     {},
 	configBatchMaxTime:                         {},
 	configTLSKey:                               {},
@@ -313,6 +315,7 @@ type Config struct {
 	LogLevel            uint32
 	LogRecovery         bool
 	LogRaft             bool
+	LogNATS             bool
 	LogSilent           bool
 	DataDir             string
 	BatchMaxMessages    int
@@ -494,6 +497,10 @@ func NewConfig(configFile string) (*Config, error) { // nolint: gocyclo
 
 	if v.IsSet(configLoggingRaft) {
 		config.LogRaft = v.GetBool(configLoggingRaft)
+	}
+
+	if v.IsSet(configLoggingNATS) {
+		config.LogNATS = v.GetBool(configLoggingNATS)
 	}
 
 	if v.IsSet(configDataDir) {

--- a/server/config.go
+++ b/server/config.go
@@ -74,12 +74,14 @@ const (
 	configTLSClientAuthEnabled = "tls.client.auth.enabled"
 	configTLSClientAuthCA      = "tls.client.auth.ca"
 
-	configNATSServers  = "nats.servers"
-	configNATSUser     = "nats.user"
-	configNATSPassword = "nats.password"
-	configNATSCert     = "nats.tls.cert"
-	configNATSKey      = "nats.tls.key"
-	configNATSCA       = "nats.tls.ca"
+	configNATSServers        = "nats.servers"
+	configNATSUser           = "nats.user"
+	configNATSPassword       = "nats.password"
+	configNATSCert           = "nats.tls.cert"
+	configNATSKey            = "nats.tls.key"
+	configNATSCA             = "nats.tls.ca"
+	configNATSEmbedded       = "nats.embedded"
+	configNATSEmbeddedConfig = "nats.embedded.config"
 
 	configStreamsRetentionMaxBytes             = "streams.retention.max.bytes"
 	configStreamsRetentionMaxMessages          = "streams.retention.max.messages"
@@ -135,6 +137,8 @@ var configKeys = map[string]struct{}{
 	configNATSCert:                             {},
 	configNATSKey:                              {},
 	configNATSCA:                               {},
+	configNATSEmbedded:                         {},
+	configNATSEmbeddedConfig:                   {},
 	configStreamsRetentionMaxBytes:             {},
 	configStreamsRetentionMaxMessages:          {},
 	configStreamsRetentionMaxAge:               {},
@@ -319,6 +323,8 @@ type Config struct {
 	TLSClientAuth       bool
 	TLSClientAuthCA     string
 	NATS                nats.Options
+	EmbeddedNATS        bool
+	EmbeddedNATSConfig  string
 	Streams             StreamsConfig
 	Clustering          ClusteringConfig
 	ActivityStream      ActivityStreamConfig
@@ -334,6 +340,7 @@ func NewDefaultConfig() *Config {
 	config.LogLevel = uint32(log.InfoLevel)
 	config.BatchMaxMessages = defaultBatchMaxMessages
 	config.MetadataCacheMaxAge = defaultMetadataCacheMaxAge
+	config.NATS.Servers = []string{nats.DefaultURL}
 	config.Clustering.ServerID = nuid.Next()
 	config.Clustering.Namespace = DefaultNamespace
 	config.Clustering.ReplicaMaxLagTime = defaultReplicaMaxLagTime
@@ -352,6 +359,12 @@ func NewDefaultConfig() *Config {
 	config.ActivityStream.PublishAckPolicy = defaultActivityStreamPublishAckPolicy
 	config.CursorsStream.AutoPauseTime = defaultCursorsStreamAutoPauseTime
 	return config
+}
+
+// NATSServersString returns a human-readable string representation of the
+// list of NATS servers.
+func (c Config) NATSServersString() string {
+	return "[" + strings.Join(c.NATS.Servers, ", ") + "]"
 }
 
 // GetListenAddress returns the address and port to listen to.
@@ -515,11 +528,21 @@ func NewConfig(configFile string) (*Config, error) { // nolint: gocyclo
 		config.TLSClientAuthCA = v.GetString(configTLSClientAuthCA)
 	}
 
-	parseNATSConfig(&config.NATS, v)
-	parseStreamsConfig(config, v)
-	parseClusteringConfig(config, v)
-	parseActivityStreamConfig(config, v)
-	parseCursorsStreamConfig(config, v)
+	if err := parseNATSConfig(config, v); err != nil {
+		return nil, err
+	}
+	if err := parseStreamsConfig(config, v); err != nil {
+		return nil, err
+	}
+	if err := parseClusteringConfig(config, v); err != nil {
+		return nil, err
+	}
+	if err := parseActivityStreamConfig(config, v); err != nil {
+		return nil, err
+	}
+	if err := parseCursorsStreamConfig(config, v); err != nil {
+		return nil, err
+	}
 
 	// If SegmentMaxAge is not set, default it to the retention time.
 	if config.Streams.SegmentMaxAge == 0 {
@@ -531,18 +554,27 @@ func NewConfig(configFile string) (*Config, error) { // nolint: gocyclo
 
 // parseNATSConfig parses the `nats` section of a config file and populates the
 // given nats.Options.
-func parseNATSConfig(opts *nats.Options, v *viper.Viper) error {
+func parseNATSConfig(config *Config, v *viper.Viper) error {
+	if v.IsSet(configNATSEmbeddedConfig) {
+		config.EmbeddedNATS = true
+		config.EmbeddedNATSConfig = v.GetString(configNATSEmbeddedConfig)
+	}
+
+	if v.IsSet(configNATSEmbedded) {
+		config.EmbeddedNATS = true
+	}
+
 	if v.IsSet(configNATSServers) {
 		servers := v.GetStringSlice(configNATSServers)
-		opts.Servers = servers
+		config.NATS.Servers = servers
 	}
 
 	if v.IsSet(configNATSUser) {
-		opts.User = v.GetString(configNATSUser)
+		config.NATS.User = v.GetString(configNATSUser)
 	}
 
 	if v.IsSet(configNATSPassword) {
-		opts.Password = v.GetString(configNATSPassword)
+		config.NATS.Password = v.GetString(configNATSPassword)
 	}
 
 	// NATS TLS config
@@ -559,7 +591,7 @@ func parseNATSConfig(opts *nats.Options, v *viper.Viper) error {
 			return err
 		}
 
-		config := &tls.Config{
+		tlsConfig := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
 		}
@@ -576,9 +608,9 @@ func parseNATSConfig(opts *nats.Options, v *viper.Viper) error {
 			caCertPool := x509.NewCertPool()
 			caCertPool.AppendCertsFromPEM(caCert)
 
-			config.RootCAs = caCertPool
+			tlsConfig.RootCAs = caCertPool
 		}
-		opts.TLSConfig = config
+		config.NATS.TLSConfig = tlsConfig
 	}
 
 	return nil

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -25,6 +25,7 @@ func TestNewConfigFromFile(t *testing.T) {
 	require.Equal(t, uint32(5), config.LogLevel)
 	require.True(t, config.LogRecovery)
 	require.True(t, config.LogRaft)
+	require.True(t, config.LogNATS)
 	require.Equal(t, "/foo", config.DataDir)
 	require.Equal(t, 10, config.BatchMaxMessages)
 	require.Equal(t, time.Second, config.BatchMaxTime)
@@ -56,6 +57,8 @@ func TestNewConfigFromFile(t *testing.T) {
 	require.Equal(t, time.Minute, config.ActivityStream.PublishTimeout)
 	require.Equal(t, client.AckPolicy_LEADER, config.ActivityStream.PublishAckPolicy)
 
+	require.True(t, config.EmbeddedNATS)
+	require.Equal(t, "nats.conf", config.EmbeddedNATSConfig)
 	require.Equal(t, []string{"nats://localhost:4222"}, config.NATS.Servers)
 	require.Equal(t, "user", config.NATS.User)
 	require.Equal(t, "pass", config.NATS.Password)

--- a/server/configs/full.yaml
+++ b/server/configs/full.yaml
@@ -12,6 +12,7 @@ logging:
   level: debug
   recovery: true
   raft: true
+  nats: true
 
 streams:
   retention.max:
@@ -52,6 +53,8 @@ activity.stream:
   publish.ack.policy: leader
 
 nats:
+  embedded: true
+  embedded.config: nats.conf
   servers:
     - nats://localhost:4222
   user: user

--- a/server/logger/logger.go
+++ b/server/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"io"
 
+	gnatsd "github.com/nats-io/nats-server/v2/server"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,4 +44,85 @@ func (l *logger) Writer() io.Writer {
 
 func (l *logger) SetWriter(writer io.Writer) {
 	l.Out = writer
+}
+
+// natsLogger implements the NATS server logger interface by writing log
+// messages to a Liftbridge logger.
+type natsLogger struct {
+	logger Logger
+}
+
+// NewNATSLogger creates a NATS logger that writes log messages to the given
+// Logger.
+func NewNATSLogger(logger Logger, enabled bool) gnatsd.Logger {
+	if enabled {
+		return &natsLogger{logger}
+	}
+	return &noopNATSLogger{logger}
+}
+
+// Noticef logs a notice statement.
+func (n *natsLogger) Noticef(format string, v ...interface{}) {
+	n.logger.Infof("nats: "+format, v...)
+}
+
+// Warnf logs a warning statement.
+func (n *natsLogger) Warnf(format string, v ...interface{}) {
+	n.logger.Warnf("nats: "+format, v...)
+}
+
+// Fatalf logs a fatal error.
+func (n *natsLogger) Fatalf(format string, v ...interface{}) {
+	n.logger.Fatalf("nats: "+format, v...)
+}
+
+// Errorf logs an error.
+func (n *natsLogger) Errorf(format string, v ...interface{}) {
+	n.logger.Errorf("nats: "+format, v...)
+}
+
+// Debugf logs a debug statement.
+func (n *natsLogger) Debugf(format string, v ...interface{}) {
+	n.logger.Debugf("nats: "+format, v...)
+}
+
+// Tracef logs a trace statement.
+func (n *natsLogger) Tracef(format string, v ...interface{}) {
+	n.logger.Debugf("nats: "+format, v...)
+}
+
+// noopNATSLogger implements the NATS server logger interface by performing a
+// no-op for each log statement with the exception of Fatalf.
+type noopNATSLogger struct {
+	logger Logger
+}
+
+// Noticef is a no-op.
+func (n *noopNATSLogger) Noticef(format string, v ...interface{}) {
+	// No-op
+}
+
+// Warnf is a no-op.
+func (n *noopNATSLogger) Warnf(format string, v ...interface{}) {
+	// No-op
+}
+
+// Fatalf logs a fatal error.
+func (n *noopNATSLogger) Fatalf(format string, v ...interface{}) {
+	n.logger.Fatalf("nats: "+format, v...)
+}
+
+// Errorf is a no-op.
+func (n *noopNATSLogger) Errorf(format string, v ...interface{}) {
+	// No-op
+}
+
+// Debugf is a no-op.
+func (n *noopNATSLogger) Debugf(format string, v ...interface{}) {
+	// No-op
+}
+
+// Tracef is a no-op.
+func (n *noopNATSLogger) Tracef(format string, v ...interface{}) {
+	// No-op
 }

--- a/server/version.go
+++ b/server/version.go
@@ -1,4 +1,4 @@
 package server
 
 // Version of the Liftbridge server.
-const Version = "v1.4.1"
+const Version = "v1.5.0"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -26,6 +26,9 @@
       "deployment": {
         "title": "Deployment"
       },
+      "embedded-nats": {
+        "title": "Embedded NATS"
+      },
       "envelope-protocol": {
         "title": "Envelope Protocol"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -10,7 +10,8 @@
     ],
     "Configuration": [
         "configuration",
-        "ha-and-consistency-configuration"
+        "ha-and-consistency-configuration",
+        "embedded-nats"
     ],
     "Deployment": [
         "deployment"


### PR DESCRIPTION
Add support for running an embedded NATS server in the Liftbridge process with new `nats.embedded` and `nats.embedded.config` settings (and flags).

Resolves #19.