### PR TITLE
Fix replication notify flood leading to high CPU usage

### DIFF
--- a/server/commitlog/commitlog.go
+++ b/server/commitlog/commitlog.go
@@ -622,8 +622,8 @@ func (l *commitLog) Segments() []*segment {
 // the given log end offset are added to the log. If the given offset is no
 // longer the log end offset, the channel is closed immediately. Waiter is an
 // opaque value that uniquely identifies the entity waiting for data.
-func (l *commitLog) NotifyLEO(waiter interface{}, leo int64) <-chan struct{} {
-	return l.activeSegment().WaitForLEO(waiter, leo)
+func (l *commitLog) NotifyLEO(waiter interface{}, expectedLEO int64) <-chan struct{} {
+	return l.activeSegment().WaitForLEO(waiter, expectedLEO, l.NewestOffset())
 }
 
 // SetReadonly marks the log as readonly. When in readonly mode, new messages

--- a/server/commitlog/segment.go
+++ b/server/commitlog/segment.go
@@ -154,11 +154,15 @@ func (s *segment) CheckSplit(logRollTime time.Duration) bool {
 }
 
 // Seal a segment from being written to. This is called on the former active
-// segment after a new segment is rolled. This is a no-op if the segment is
-// already sealed.
+// segment after a new segment is rolled or when the segment is closed. This is
+// a no-op if the segment is already sealed.
 func (s *segment) Seal() {
 	s.Lock()
 	defer s.Unlock()
+	s.seal()
+}
+
+func (s *segment) seal() {
 	if s.sealed {
 		return
 	}
@@ -329,6 +333,7 @@ func (s *segment) close() error {
 		return err
 	}
 	s.closed = true
+	s.seal()
 	return nil
 }
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -247,6 +247,30 @@
       },
       "version-v1.4.1/version-v1.4.1-quick-start": {
         "title": "Quick Start"
+      },
+      "version-v1.5.0/version-v1.5.0-client-implementation": {
+        "title": "Client Implementation Guidance"
+      },
+      "version-v1.5.0/version-v1.5.0-concepts": {
+        "title": "Concepts"
+      },
+      "version-v1.5.0/version-v1.5.0-configuration": {
+        "title": "Configuration"
+      },
+      "version-v1.5.0/version-v1.5.0-embedded-nats": {
+        "title": "Embedded NATS"
+      },
+      "version-v1.5.0/version-v1.5.0-quick-start": {
+        "title": "Quick Start"
+      },
+      "version-v1.5.0/version-v1.5.0-replication-protocol": {
+        "title": "Replication Protocol"
+      },
+      "version-v1.5.0/version-v1.5.0-roadmap": {
+        "title": "Product Roadmap"
+      },
+      "version-v1.5.0/version-v1.5.0-scalability-configuration": {
+        "title": "Configuring for Scalability"
       }
     },
     "links": {


### PR DESCRIPTION
Fix an issue where the replication waiter logic which occurs when a
follower is caught up with the leader causes a flood of notify and
replication requests.

This fixes issue #313.

Also fix an edge case deadlock issue when there is a leader change for a
partition but there is no metadata leader.