### PR TITLE
Add a Raft log listener

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -111,6 +111,14 @@ func (s *Server) Apply(l *raft.Log) interface{} {
 		panic(err)
 	}
 	s.activity.SignalCommit()
+
+	// Send the Raft log entry to listeners.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, listener := range s.raftLogListeners {
+		listener.Receive(&RaftLog{log})
+	}
+
 	return value
 }
 

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -116,7 +116,7 @@ func (s *Server) Apply(l *raft.Log) interface{} {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, listener := range s.raftLogListeners {
-		listener.Receive(&RaftLog{log})
+		listener.Receive(&RaftLog{l})
 	}
 
 	return value

--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,16 @@ const (
 	cursorsStream       = "__cursors"
 )
 
+// RaftLog represents an entry into the Raft log.
+type RaftLog struct {
+	*proto.RaftLog
+}
+
+// RaftLogListener is a listener for Raft logs.
+type RaftLogListener interface {
+	Receive(*RaftLog)
+}
+
 // Server is the main Liftbridge object. Create it by calling New or
 // RunServerWithConfig.
 type Server struct {
@@ -71,6 +81,7 @@ type Server struct {
 	goroutineWait      sync.WaitGroup
 	activity           *activityManager
 	cursors            *cursorManager
+	raftLogListeners   []RaftLogListener
 }
 
 // RunServerWithConfig creates and starts a new Server with the given
@@ -277,6 +288,13 @@ func (s *Server) GetListenPort() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.port
+}
+
+// AddRaftLogListener adds a Raft log listener.
+func (s *Server) AddRaftLogListener(listener RaftLogListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.raftLogListeners = append(s.raftLogListeners, listener)
 }
 
 // getConnectionAddress returns the connection address that should be used by

--- a/server/server.go
+++ b/server/server.go
@@ -44,7 +44,7 @@ const (
 
 // RaftLog represents an entry into the Raft log.
 type RaftLog struct {
-	*proto.RaftLog
+	*raft.Log
 }
 
 // RaftLogListener is a listener for Raft logs.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1899,4 +1900,58 @@ func TestPublishNoSuchPartition(t *testing.T) {
 	defer cancel()
 	_, err = client.Publish(ctx, name, []byte("hello"), lift.ToPartition(42))
 	require.Error(t, err)
+}
+
+type raftLogListener struct {
+	receiver func(log *RaftLog)
+}
+
+func (l *raftLogListener) Receive(log *RaftLog) {
+	l.receiver(log)
+}
+
+// Ensure Raft log listeners receive logs.
+func TestRaftLogListener(t *testing.T) {
+	defer cleanupStorage(t)
+
+	// Configure first server.
+	s1Config := getTestConfig("a", true, 0)
+	s1 := runServerWithConfig(t, s1Config)
+	defer s1.Stop()
+
+	gotLogs := make(chan struct{})
+	logs := make([]*RaftLog, 0, 2)
+	s1.AddRaftLogListener(&raftLogListener{func(log *RaftLog) {
+		logs = append(logs, log)
+		if len(logs) == 2 {
+			close(gotLogs)
+		}
+	}})
+
+	// Wait for server to elect itself leader.
+	getMetadataLeader(t, 10*time.Second, s1)
+
+	client, err := lift.Connect([]string{"localhost:" + strconv.Itoa(s1.GetListenPort())})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// Create stream.
+	name := "foo"
+	subject := "foo"
+	err = client.CreateStream(context.Background(), subject, name)
+	require.NoError(t, err)
+
+	// Delete stream.
+	err = client.DeleteStream(context.Background(), name)
+	require.NoError(t, err)
+
+	// Wait to receive the Raft logs.
+	select {
+	case <-gotLogs:
+		require.Len(t, logs, 2)
+		require.Equal(t, proto.Op_CREATE_STREAM, logs[0].Op)
+		require.Equal(t, proto.Op_DELETE_STREAM, logs[1].Op)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Did not receive expected Raft logs")
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1920,9 +1920,13 @@ func TestRaftLogListener(t *testing.T) {
 	defer s1.Stop()
 
 	gotLogs := make(chan struct{})
-	logs := make([]*RaftLog, 0, 2)
+	logs := make([]*proto.RaftLog, 0, 2)
 	s1.AddRaftLogListener(&raftLogListener{func(log *RaftLog) {
-		logs = append(logs, log)
+		protoLog := &proto.RaftLog{}
+		err := protoLog.Unmarshal(log.Data)
+		require.NoError(t, err)
+
+		logs = append(logs, protoLog)
 		if len(logs) == 2 {
 			close(gotLogs)
 		}


### PR DESCRIPTION
This PR adds a listener for Raft log entries to the `Server`.

Fixes https://github.com/liftbridge-io/liftbridge/issues/335.