### PR TITLE
Fix possibility for HW to move backwards

### DIFF
--- a/server/partition.go
+++ b/server/partition.go
@@ -474,6 +474,10 @@ func (p *partition) becomeLeader(epoch uint64) error {
 		}
 	}
 
+	// Update this replica's latest offset to ensure it's up to date.
+	rep := p.isr[p.srv.config.Clustering.ServerID]
+	rep.updateLatestOffset(p.log.NewestOffset())
+
 	// Start message processing loop.
 	recvChan := make(chan *nats.Msg, recvChannelSize)
 	p.stopLeader = make(chan struct{})


### PR DESCRIPTION
Fix a bug which made it possible for the HW to move backwards in the
event of a leader failover. Fixes #319.