### PR TITLE
Fix race with raftLogListeners mutex

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -118,11 +118,11 @@ func (s *Server) Apply(l *raft.Log) interface{} {
 	s.activity.SignalCommit()
 
 	// Send the Raft log entry to listeners.
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.raftLogListenersMu.RLock()
 	for _, listener := range s.raftLogListeners {
 		listener.Receive(&RaftLog{l})
 	}
+	s.raftLogListenersMu.RUnlock()
 
 	return value
 }

--- a/server/server.go
+++ b/server/server.go
@@ -81,6 +81,7 @@ type Server struct {
 	goroutineWait      sync.WaitGroup
 	activity           *activityManager
 	cursors            *cursorManager
+	raftLogListenersMu sync.RWMutex
 	raftLogListeners   []RaftLogListener
 }
 
@@ -292,8 +293,8 @@ func (s *Server) GetListenPort() int {
 
 // AddRaftLogListener adds a Raft log listener.
 func (s *Server) AddRaftLogListener(listener RaftLogListener) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.raftLogListenersMu.Lock()
+	defer s.raftLogListenersMu.Unlock()
 	s.raftLogListeners = append(s.raftLogListeners, listener)
 }
 


### PR DESCRIPTION
Fix a race condition related to the mutex guarding raftLogListeners by
replacing it with a finer-grained mutex.