### PR TITLE
Allow cursors.stream.auto.pause.time to be changed

### DIFF
--- a/server/metadata.go
+++ b/server/metadata.go
@@ -1084,7 +1084,7 @@ func (m *metadataAPI) AddStream(protoStream *proto.Stream, recovered bool, epoch
 
 	config := protoStream.GetConfig()
 	creationTime := time.Unix(0, protoStream.CreationTimestamp)
-	stream := newStream(protoStream.Name, protoStream.Subject, config, creationTime)
+	stream := newStream(protoStream.Name, protoStream.Subject, config, creationTime, m.config)
 	m.streams[protoStream.Name] = stream
 
 	for _, partition := range protoStream.Partitions {

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,9 @@ const (
 	cursorsStream       = "__cursors"
 )
 
+// reservedStreams contains reserved internal stream names.
+var reservedStreams = []string{activityStream, cursorsStream}
+
 // RaftLog represents an entry into the Raft log.
 type RaftLog struct {
 	*raft.Log


### PR DESCRIPTION
Previously the `cursors.stream.auto.pause.time` configuration could not be changed once the cursors stream was created. This allows it to be changed in the configuration file and take effect upon server restart.

This is related to the discussion in https://github.com/liftbridge-io/liftbridge/issues/390.

This also prevents clients from creating or deleting "reserved" streams, i.e. `__cursors` and `__activity`.