### PR TITLE
Fix potential for serving stale cursors

### DIFF
--- a/server/partition.go
+++ b/server/partition.go
@@ -862,6 +862,11 @@ func (p *partition) becomeLeader(epoch uint64) error {
 	p.isLeading = true
 	p.isFollowing = false
 
+	// Notify the cursor manager if we've come leader for a cursor partition.
+	if p.Stream == cursorsStream {
+		p.srv.cursors.BecomePartitionLeader()
+	}
+
 	return nil
 }
 

--- a/server/partition.go
+++ b/server/partition.go
@@ -862,7 +862,7 @@ func (p *partition) becomeLeader(epoch uint64) error {
 	p.isLeading = true
 	p.isFollowing = false
 
-	// Notify the cursor manager if we've come leader for a cursor partition.
+	// Notify the cursor manager if we've become leader for a cursor partition.
 	if p.Stream == cursorsStream {
 		p.srv.cursors.BecomePartitionLeader()
 	}


### PR DESCRIPTION
Clear the cursor cache when a server becomes the leader for a cursor
partition to avoid the potential for serving stale cursors.

Fixes #319