### PR TITLE
Fix panic caused by partition queue dispose

### DIFF
--- a/server/partition.go
+++ b/server/partition.go
@@ -1283,8 +1283,9 @@ func (p *partition) processPendingMessage(offset int64, msg *commitlog.Message) 
 		p.sendAck(ack)
 	}
 	if err := p.commitQueue.Put(ack); err != nil {
-		// This is very bad and should not happen.
-		panic(fmt.Sprintf("Failed to add message to commit queue: %v", err))
+		// An error here indicates the queue was disposed as a result of the
+		// leader stepping down.
+		p.srv.logger.Errorf("Failed to add message to commit queue for partition %s: %v", p, err)
 	}
 }
 


### PR DESCRIPTION
We don't need to panic when there is an error adding to the commit queue
since Liftbridge's replication protocol will handle uncommitted
messages.