### PR TITLE
Remove override logic for tls-client-* flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,12 +76,6 @@ func overrideFromFlags(c *cli.Context, config *server.Config) error {
 	if c.IsSet("tls-key") {
 		config.TLSKey = c.String("tls-key")
 	}
-	if c.IsSet("tls-client-auth") {
-		config.TLSClientAuth = c.Bool("tls-client-auth")
-	}
-	if c.IsSet("tls-client-auth-ca") {
-		config.TLSClientAuthCA = c.String("tls-client-auth-ca")
-	}
 	if c.IsSet("nats-servers") {
 		natsServers, err := normalizeNatsServers(c.StringSlice("nats-servers"))
 		if err != nil {


### PR DESCRIPTION
Remove the override logic for the tls-client-* flags since these flags
were never exposed.