### PR TITLE
Fix corrupt index file causing panic on startup (#411)

### DIFF
--- a/server/commitlog/segment_test.go
+++ b/server/commitlog/segment_test.go
@@ -2,6 +2,7 @@ package commitlog
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -210,4 +211,152 @@ func TestSegmentWaitForLEO(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Expected channel to be closed")
 	}
+}
+
+// Ensure a corrupt index is detected and rebuilt from the log file.
+func TestSegmentCorruptIndexRecovery(t *testing.T) {
+	dir := tempDir(t)
+	defer remove(t, dir)
+
+	// Create a segment with some data
+	s := createSegment(t, dir, 0, 1024)
+	for i := 0; i < 5; i++ {
+		writeToSegment(t, s, int64(i), []byte("test data"))
+	}
+	require.Equal(t, int64(5), s.MessageCount())
+	require.Equal(t, int64(0), s.FirstOffset())
+	require.Equal(t, int64(4), s.LastOffset())
+
+	// Close the segment
+	require.NoError(t, s.Close())
+
+	// Corrupt the index by writing garbage to it
+	indexPath := s.indexPath()
+	require.NoError(t, corruptIndexFile(indexPath))
+
+	// Reopen the segment - it should detect corruption and rebuild the index
+	s2, err := newSegment(dir, 0, 1024, false, "")
+	require.NoError(t, err)
+
+	// Verify the index was rebuilt correctly
+	require.Equal(t, int64(5), s2.MessageCount())
+	require.Equal(t, int64(0), s2.FirstOffset())
+	require.Equal(t, int64(4), s2.LastOffset())
+
+	// Verify we can still read all messages
+	scanner := newSegmentScanner(s2)
+	for i := 0; i < 5; i++ {
+		_, entry, err := scanner.Scan()
+		require.NoError(t, err)
+		require.Equal(t, int64(i), entry.Offset)
+	}
+}
+
+// Ensure index rebuild works with an empty log file.
+func TestSegmentCorruptIndexRecoveryEmptyLog(t *testing.T) {
+	dir := tempDir(t)
+	defer remove(t, dir)
+
+	// Create an empty segment
+	s := createSegment(t, dir, 0, 1024)
+	require.NoError(t, s.Close())
+
+	// Corrupt the index by writing garbage to it
+	indexPath := s.indexPath()
+	require.NoError(t, corruptIndexFile(indexPath))
+
+	// Reopen the segment - it should detect corruption and rebuild the index
+	s2, err := newSegment(dir, 0, 1024, false, "")
+	require.NoError(t, err)
+
+	// Verify the segment is still empty
+	require.Equal(t, int64(0), s2.MessageCount())
+	require.True(t, s2.IsEmpty())
+}
+
+// Ensure index rebuild handles truncated index (less entries than log has).
+func TestSegmentCorruptIndexTruncated(t *testing.T) {
+	dir := tempDir(t)
+	defer remove(t, dir)
+
+	// Create a segment with some data
+	s := createSegment(t, dir, 0, 1024)
+	for i := 0; i < 3; i++ {
+		writeToSegment(t, s, int64(i), []byte("test data"))
+	}
+	require.NoError(t, s.Close())
+
+	// Corrupt the index by truncating to just 1 entry (20 bytes)
+	// The log has 3 messages but index will only have 1 entry
+	indexPath := s.indexPath()
+	require.NoError(t, truncateIndexFile(indexPath, 20))
+
+	// Corrupt the single remaining entry to trigger rebuild
+	require.NoError(t, corruptIndexFile(indexPath))
+
+	// Reopen the segment - it should detect corruption and rebuild the index
+	s2, err := newSegment(dir, 0, 1024, false, "")
+	require.NoError(t, err)
+
+	// Verify the index was rebuilt correctly from the log file
+	require.Equal(t, int64(3), s2.MessageCount())
+}
+
+// corruptIndexFile writes garbage to an index file to corrupt it.
+// The corruption makes the last entry have an offset < baseOffset.
+func corruptIndexFile(path string) error {
+	f, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Read current file size to find the last entry
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Find the position of the last valid entry by scanning from the start
+	// The index has 20-byte entries (entryWidth)
+	entryWidth := int64(20)
+	buf := make([]byte, entryWidth)
+	var lastEntryPos int64 = -1
+
+	for pos := int64(0); pos < info.Size(); pos += entryWidth {
+		_, err := f.ReadAt(buf, pos)
+		if err != nil {
+			break
+		}
+		// Check if this entry is empty (all zeros for position, timestamp, size)
+		// Entry format: offset(4) + timestamp(8) + position(4) + size(4)
+		// Check if timestamp, position, and size are all zero
+		isZero := true
+		for i := 4; i < 20; i++ { // Skip offset, check rest
+			if buf[i] != 0 {
+				isZero = false
+				break
+			}
+		}
+		if isZero {
+			break
+		}
+		lastEntryPos = pos
+	}
+
+	if lastEntryPos < 0 {
+		// No entries found, corrupt the first position
+		lastEntryPos = 0
+	}
+
+	// Write garbage to make offset negative (< baseOffset of 0)
+	// offset is stored as int32 at the start of each entry
+	garbage := []byte{0xFF, 0xFF, 0xFF, 0xFF} // -1 as int32
+	_, err = f.WriteAt(garbage, lastEntryPos)
+	return err
+}
+
+// truncateIndexFile truncates an index file to the specified size.
+func truncateIndexFile(path string, size int64) error {
+	return os.Truncate(path, size)
 }


### PR DESCRIPTION
When an index file becomes corrupted (e.g., due to unclean shutdown or disk errors), Liftbridge would panic on startup with "corrupt index file" error, leaving users unable to recover without manual intervention.

This commit implements automatic index recovery by:
- Detecting index corruption during segment initialization
- Deleting the corrupt index file
- Scanning the log file to rebuild index entries
- Continuing startup with the rebuilt index

The fix ensures fault tolerance by gracefully recovering from index corruption instead of failing hard. The log file is the source of truth, so as long as it's intact, the index can be reconstructed.