### PR TITLE
fix: snapshot restore panic during startup (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ Fixed a startup panic when index files become corrupted.
 - Modified `setupIndex()` to catch `errIndexCorrupt` and attempt automatic recovery
 - Added tests for corrupt index detection and recovery scenarios
 
+#### Snapshot Restore Panic ([#414](https://github.com/liftbridge-io/liftbridge/issues/414))
+Fixed a startup panic when restoring from a Raft snapshot.
+
+**Problem**: When a node started and restored state from a Raft snapshot, it would panic with a nil pointer dereference at `partition.go:1311`. This occurred because partitions were trying to start leader/follower loops before the API server was initialized.
+
+**Solution**: Mark streams and consumer groups as "recovered" during snapshot restore, deferring their startup until `finishedRecovery()` is called after log replay completes. This ensures `s.api` is initialized before partitions attempt to start.
+
+**Changes**:
+- Modified `Restore()` in fsm.go to pass `recovered=true` to `applyCreateStream()` and `applyCreateConsumerGroup()`
+
 ### Raft v1.7.3 Compatibility
 This release enables compatibility with hashicorp/raft v1.7.3, which includes:
 - Pre-vote protocol (enabled by default)

--- a/server/fsm.go
+++ b/server/fsm.go
@@ -423,13 +423,16 @@ func (s *Server) Restore(snapshot io.ReadCloser) error {
 	if err := s.metadata.Reset(); err != nil {
 		return err
 	}
+	// Mark streams and groups as recovered so they don't start leader/follower
+	// loops until finishedRecovery() is called after log replay completes.
+	// This is critical because s.api is not yet initialized during Restore().
 	for _, stream := range snap.Streams {
-		if err := s.applyCreateStream(stream, false, 0); err != nil {
+		if err := s.applyCreateStream(stream, true, 0); err != nil {
 			return err
 		}
 	}
 	for _, group := range snap.Groups {
-		if err := s.applyCreateConsumerGroup(group, false); err != nil {
+		if err := s.applyCreateConsumerGroup(group, true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixed a startup panic when restoring from a Raft snapshot. When a node started and restored state from a Raft snapshot, it would panic with a nil pointer dereference at partition.go:1311.

Root cause: During Restore(), streams were created with recovered=false, causing partitions to immediately start leader/follower loops. This tried to access s.api which was still nil (not initialized until startAPIServer() which runs after setupMetadataRaft()).

Fix: Pass recovered=true to applyCreateStream() and applyCreateConsumerGroup() during Restore(). This defers starting partitions until finishedRecovery() is called after log replay completes, when s.api is guaranteed to be initialized.