### PR TITLE
Fix signal handling race with embedded NATS (#373)

### DIFF
--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -110,6 +110,13 @@ rebuilds corrupt indexes from the log file.
 Fixed startup panic when restoring from a Raft snapshot. Partitions now defer
 starting leader/follower loops until after recovery completes.
 
+### Bug Fixes: Signal Handling Race ([#373](https://github.com/liftbridge-io/liftbridge/issues/373))
+
+**Status**: Done (v26.01.1)
+
+Fixed race condition when using embedded NATS that could prevent graceful shutdown.
+Set `opts.NoSigs = true` to disable NATS's signal handling.
+
 ---
 
 ## Phase 2: Enterprise Features (v26.03)

--- a/server/server.go
+++ b/server/server.go
@@ -348,6 +348,12 @@ func (s *Server) startEmbeddedNATS() error {
 	if err != nil {
 		return err
 	}
+	// Disable NATS signal handling to prevent race with Liftbridge's signal
+	// handler. Without this, both servers register handlers for SIGINT/SIGTERM
+	// and whichever runs first wins - if NATS wins, it calls os.Exit()
+	// immediately, preventing Liftbridge from performing graceful shutdown.
+	// See: https://github.com/liftbridge-io/liftbridge/issues/373
+	opts.NoSigs = true
 	s.embeddedNATS, err = gnatsd.NewServer(opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
When using embedded NATS, both servers registered signal handlers for SIGINT/SIGTERM, causing a race condition. Whichever handler ran first would win - if NATS won, it called os.Exit() immediately, preventing Liftbridge from performing graceful shutdown.

Fix: Set opts.NoSigs = true when creating embedded NATS server to disable NATS's signal handling, allowing Liftbridge to handle all signals for proper graceful shutdown.