### PR TITLE
Fix nil pointer dereference when leader not in ISR (#354)

### DIFF
--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -117,6 +117,14 @@ starting leader/follower loops until after recovery completes.
 Fixed race condition when using embedded NATS that could prevent graceful shutdown.
 Set `opts.NoSigs = true` to disable NATS's signal handling.
 
+### Bug Fixes: Leader Not In ISR Panic ([#354](https://github.com/liftbridge-io/liftbridge/issues/354))
+
+**Status**: Done (v26.01.1)
+
+Fixed nil pointer dereference when partition leader is not in ISR during snapshot restore.
+Added defensive check in `becomeLeader()` to add self to ISR if missing, allowing recovery
+from corrupt snapshots.
+
 ---
 
 ## Phase 2: Enterprise Features (v26.03)


### PR DESCRIPTION
When restoring from a Raft snapshot, if the snapshot contained inconsistent state where a partition's leader was not in its ISR, the server would panic with a nil pointer dereference.

This could happen if a node was removed from the ISR via ShrinkISR but a snapshot was taken before a new leader election occurred.

Changes:
- Add defensive nil check in becomeLeader() before accessing ISR map
- Add auto-recovery logic to add self to ISR if missing
- Add test case TestPartitionBecomeLeaderNotInISR
- Update CHANGELOG.md and roadmap.md