### PR TITLE
Add telemetry support for anonymous usage statistics

### DIFF
--- a/server/telemetry/telemetry.go
+++ b/server/telemetry/telemetry.go
@@ -1,0 +1,277 @@
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/liftbridge-io/liftbridge/server/logger"
+)
+
+const (
+	// DefaultEndpoint is the telemetry collection endpoint (hardcoded, not configurable)
+	DefaultEndpoint = "https://telemetry.basekick.net/api/v1/liftbridge/telemetry"
+
+	// DefaultInterval is the telemetry reporting interval
+	DefaultInterval = 24 * time.Hour
+
+	// instanceIDFile stores the persistent instance ID
+	instanceIDFile = ".instance_id"
+)
+
+// Config holds telemetry configuration
+type Config struct {
+	Enabled  bool          // Enable telemetry (default: true)
+	Interval time.Duration // Reporting interval (default: 24h)
+	DataDir  string        // Directory for instance ID file
+}
+
+// DefaultConfig returns the default telemetry configuration
+func DefaultConfig() *Config {
+	return &Config{
+		Enabled:  true,
+		Interval: DefaultInterval,
+		DataDir:  "./data",
+	}
+}
+
+// Collector collects and sends telemetry data
+type Collector struct {
+	config     *Config
+	instanceID string
+	version    string
+	startTime  time.Time
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	client *http.Client
+	logger logger.Logger
+}
+
+// TelemetryPayload represents the data sent to the telemetry endpoint
+type TelemetryPayload struct {
+	InstanceID        string  `json:"instance_id"`
+	Timestamp         string  `json:"timestamp"`
+	LiftbridgeVersion string  `json:"liftbridge_version"`
+	OS                OSInfo  `json:"os"`
+	CPU               CPUInfo `json:"cpu"`
+	Memory            MemInfo `json:"memory"`
+}
+
+// OSInfo contains operating system information
+type OSInfo struct {
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	Architecture string `json:"architecture"`
+	Platform     string `json:"platform"`
+}
+
+// CPUInfo contains CPU information
+type CPUInfo struct {
+	PhysicalCores *int `json:"physical_cores"`
+	LogicalCores  *int `json:"logical_cores"`
+	FrequencyMHz  *int `json:"frequency_mhz"`
+}
+
+// MemInfo contains memory information
+type MemInfo struct {
+	TotalGB *float64 `json:"total_gb"`
+}
+
+// New creates a new telemetry collector
+func New(cfg *Config, version string, log logger.Logger) (*Collector, error) {
+	if cfg == nil {
+		cfg = DefaultConfig()
+	}
+
+	// Load or generate instance ID
+	instanceID, err := loadOrCreateInstanceID(cfg.DataDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance ID: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &Collector{
+		config:     cfg,
+		instanceID: instanceID,
+		version:    version,
+		startTime:  time.Now(),
+		ctx:        ctx,
+		cancel:     cancel,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: log,
+	}
+
+	return c, nil
+}
+
+// Start begins periodic telemetry collection
+func (c *Collector) Start() {
+	if !c.config.Enabled {
+		c.logger.Info("Telemetry is disabled")
+		return
+	}
+
+	c.logger.Infof("Telemetry collector started [instance_id=%s, interval=%s]",
+		c.instanceID, c.config.Interval)
+
+	c.wg.Add(1)
+	go c.run()
+}
+
+// Stop stops the telemetry collector
+func (c *Collector) Stop() {
+	c.cancel()
+	c.wg.Wait()
+	c.logger.Info("Telemetry collector stopped")
+}
+
+// GetInstanceID returns the instance ID
+func (c *Collector) GetInstanceID() string {
+	return c.instanceID
+}
+
+func (c *Collector) run() {
+	defer c.wg.Done()
+
+	// Send initial telemetry beacon
+	c.logger.Info("Sending initial telemetry beacon")
+	c.sendTelemetry()
+
+	// Then send periodically
+	ticker := time.NewTicker(c.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.sendTelemetry()
+		case <-c.ctx.Done():
+			return
+		}
+	}
+}
+
+func (c *Collector) sendTelemetry() {
+	payload := c.collectPayload()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		c.logger.Errorf("Failed to marshal telemetry payload: %v", err)
+		return
+	}
+
+	c.logger.Infof("Sending telemetry [instance_id=%s]", c.instanceID)
+
+	req, err := http.NewRequestWithContext(c.ctx, "POST", DefaultEndpoint, bytes.NewReader(data))
+	if err != nil {
+		c.logger.Errorf("Failed to create telemetry request: %v", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("Liftbridge/%s", c.version))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Warnf("Failed to send telemetry: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		c.logger.Warnf("Telemetry endpoint returned error status: %d", resp.StatusCode)
+		return
+	}
+
+	c.logger.Infof("Telemetry sent successfully [status=%d]", resp.StatusCode)
+}
+
+func (c *Collector) collectPayload() *TelemetryPayload {
+	// Get CPU info
+	numCPU := runtime.NumCPU()
+
+	// Get memory info (total system memory via runtime)
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+	totalGB := float64(memStats.Sys) / (1024 * 1024 * 1024)
+
+	// Build OS platform string
+	platform := fmt.Sprintf("%s-%s-%s", runtime.GOOS, runtime.Version(), runtime.GOARCH)
+
+	return &TelemetryPayload{
+		InstanceID:        c.instanceID,
+		Timestamp:         time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		LiftbridgeVersion: c.version,
+		OS: OSInfo{
+			Name:         runtime.GOOS,
+			Version:      runtime.Version(),
+			Architecture: runtime.GOARCH,
+			Platform:     platform,
+		},
+		CPU: CPUInfo{
+			PhysicalCores: &numCPU,
+			LogicalCores:  &numCPU,
+			FrequencyMHz:  nil, // Not easily available in Go without cgo
+		},
+		Memory: MemInfo{
+			TotalGB: &totalGB,
+		},
+	}
+}
+
+func loadOrCreateInstanceID(dataDir string) (string, error) {
+	// Ensure data directory exists
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	idPath := filepath.Join(dataDir, instanceIDFile)
+
+	// Try to load existing ID
+	data, err := os.ReadFile(idPath)
+	if err == nil && len(data) > 0 {
+		return string(bytes.TrimSpace(data)), nil
+	}
+
+	// Generate new ID as UUID format
+	id, err := generateUUID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate instance ID: %w", err)
+	}
+
+	// Save ID
+	if err := os.WriteFile(idPath, []byte(id), 0644); err != nil {
+		return "", fmt.Errorf("failed to save instance ID: %w", err)
+	}
+
+	return id, nil
+}
+
+func generateUUID() (string, error) {
+	// Generate UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+
+	// Set version (4) and variant bits
+	b[6] = (b[6] & 0x0f) | 0x40 // Version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // Variant is 10
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/server/telemetry/telemetry_test.go
+++ b/server/telemetry/telemetry_test.go
@@ -1,0 +1,363 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/liftbridge-io/liftbridge/server/logger"
+)
+
+func TestGenerateUUID(t *testing.T) {
+	uuid, err := generateUUID()
+	require.NoError(t, err)
+
+	// UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+	uuidRegex := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	require.True(t, uuidRegex.MatchString(uuid), "UUID should match v4 format: %s", uuid)
+
+	// Generate another UUID and ensure they're different
+	uuid2, err := generateUUID()
+	require.NoError(t, err)
+	require.NotEqual(t, uuid, uuid2, "UUIDs should be unique")
+}
+
+func TestLoadOrCreateInstanceID(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Test creating new instance ID
+	id1, err := loadOrCreateInstanceID(tmpDir)
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	// Verify file was created
+	idPath := filepath.Join(tmpDir, instanceIDFile)
+	_, err = os.Stat(idPath)
+	require.NoError(t, err)
+
+	// Test loading existing instance ID
+	id2, err := loadOrCreateInstanceID(tmpDir)
+	require.NoError(t, err)
+	require.Equal(t, id1, id2, "Should return same instance ID on subsequent calls")
+}
+
+func TestLoadOrCreateInstanceID_ExistingID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Pre-create an instance ID file
+	existingID := "existing-test-id-12345"
+	idPath := filepath.Join(tmpDir, instanceIDFile)
+	err = os.WriteFile(idPath, []byte(existingID), 0644)
+	require.NoError(t, err)
+
+	// Load should return the existing ID
+	id, err := loadOrCreateInstanceID(tmpDir)
+	require.NoError(t, err)
+	require.Equal(t, existingID, id)
+}
+
+func TestCollectPayload(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0-test", log)
+	require.NoError(t, err)
+
+	payload := collector.collectPayload()
+
+	// Verify required fields
+	require.NotEmpty(t, payload.InstanceID)
+	require.NotEmpty(t, payload.Timestamp)
+	require.Equal(t, "1.0.0-test", payload.LiftbridgeVersion)
+
+	// Verify OS info
+	require.NotEmpty(t, payload.OS.Name)
+	require.NotEmpty(t, payload.OS.Version)
+	require.NotEmpty(t, payload.OS.Architecture)
+	require.NotEmpty(t, payload.OS.Platform)
+
+	// Verify CPU info
+	require.NotNil(t, payload.CPU.PhysicalCores)
+	require.NotNil(t, payload.CPU.LogicalCores)
+	require.Greater(t, *payload.CPU.LogicalCores, 0)
+
+	// Verify memory info
+	require.NotNil(t, payload.Memory.TotalGB)
+	require.Greater(t, *payload.Memory.TotalGB, 0.0)
+
+	// Verify timestamp format (ISO 8601)
+	_, err = time.Parse("2006-01-02T15:04:05Z", payload.Timestamp)
+	require.NoError(t, err, "Timestamp should be valid ISO 8601 format")
+}
+
+func TestNew(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0", log)
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	require.NotEmpty(t, collector.instanceID)
+	require.Equal(t, "1.0.0", collector.version)
+}
+
+func TestNew_DefaultConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	// Test with nil config - should use defaults
+	// Note: This will use "./data" as DataDir which may not exist in test environment
+	// so we'll test with explicit config instead
+	cfg := DefaultConfig()
+	cfg.DataDir = tmpDir
+
+	collector, err := New(cfg, "dev", log)
+	require.NoError(t, err)
+	require.NotNil(t, collector)
+	require.True(t, collector.config.Enabled)
+	require.Equal(t, DefaultInterval, collector.config.Interval)
+}
+
+func TestGetInstanceID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0", log)
+	require.NoError(t, err)
+
+	id := collector.GetInstanceID()
+	require.NotEmpty(t, id)
+	require.Equal(t, collector.instanceID, id)
+}
+
+func TestStartStop(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0", log)
+	require.NoError(t, err)
+
+	// Start should not block
+	collector.Start()
+
+	// Give it a moment to start the goroutine
+	time.Sleep(10 * time.Millisecond)
+
+	// Stop should complete without hanging
+	done := make(chan struct{})
+	go func() {
+		collector.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not complete in time")
+	}
+}
+
+func TestStartDisabled(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  false,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0", log)
+	require.NoError(t, err)
+
+	// Start should return immediately when disabled
+	collector.Start()
+
+	// Stop should also work fine
+	collector.Stop()
+}
+
+func TestSendTelemetry(t *testing.T) {
+	var receivedPayload TelemetryPayload
+	requestReceived := make(chan struct{})
+
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		require.Equal(t, "POST", r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Contains(t, r.Header.Get("User-Agent"), "Liftbridge/")
+
+		// Decode payload
+		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+		close(requestReceived)
+	}))
+	defer server.Close()
+
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.0.0-test", log)
+	require.NoError(t, err)
+
+	// Override the endpoint for testing by calling sendTelemetryTo directly
+	// Since we hardcoded the endpoint, we need to test via the mock server approach
+	// For this test, we'll create a custom test that uses the test server URL
+
+	// Create a test-specific send function
+	payload := collector.collectPayload()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", server.URL, bytes.NewReader(data))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Liftbridge/1.0.0-test")
+
+	resp, err := collector.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Wait for server to receive request
+	select {
+	case <-requestReceived:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Server did not receive request")
+	}
+
+	// Verify received payload
+	require.NotEmpty(t, receivedPayload.InstanceID)
+	require.Equal(t, "1.0.0-test", receivedPayload.LiftbridgeVersion)
+	require.NotEmpty(t, receivedPayload.OS.Name)
+	require.NotNil(t, receivedPayload.CPU.LogicalCores)
+	require.NotNil(t, receivedPayload.Memory.TotalGB)
+}
+
+func TestPayloadJSONFormat(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "telemetry-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	log := logger.NewLogger(0)
+	log.Silent(true)
+
+	cfg := &Config{
+		Enabled:  true,
+		Interval: time.Hour,
+		DataDir:  tmpDir,
+	}
+
+	collector, err := New(cfg, "1.2.0", log)
+	require.NoError(t, err)
+
+	payload := collector.collectPayload()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	// Verify JSON structure by unmarshaling into a map
+	var jsonMap map[string]interface{}
+	err = json.Unmarshal(data, &jsonMap)
+	require.NoError(t, err)
+
+	// Check top-level keys
+	require.Contains(t, jsonMap, "instance_id")
+	require.Contains(t, jsonMap, "timestamp")
+	require.Contains(t, jsonMap, "liftbridge_version")
+	require.Contains(t, jsonMap, "os")
+	require.Contains(t, jsonMap, "cpu")
+	require.Contains(t, jsonMap, "memory")
+
+	// Check nested OS keys
+	osMap := jsonMap["os"].(map[string]interface{})
+	require.Contains(t, osMap, "name")
+	require.Contains(t, osMap, "version")
+	require.Contains(t, osMap, "architecture")
+	require.Contains(t, osMap, "platform")
+
+	// Check nested CPU keys
+	cpuMap := jsonMap["cpu"].(map[string]interface{})
+	require.Contains(t, cpuMap, "physical_cores")
+	require.Contains(t, cpuMap, "logical_cores")
+	require.Contains(t, cpuMap, "frequency_mhz")
+
+	// Check nested memory keys
+	memMap := jsonMap["memory"].(map[string]interface{})
+	require.Contains(t, memMap, "total_gb")
+}


### PR DESCRIPTION
Implement telemetry collection following the Arc pattern to send anonymous system information to help improve Liftbridge. Features:

- New telemetry package with Collector for periodic data transmission
- Sends instance ID, version, OS, CPU, and memory info every 24 hours
- Enabled by default (opt-out via config or environment variable)
- Hardcoded endpoint: telemetry.basekick.net/api/v1/liftbridge/telemetry
- Persistent instance ID stored in data directory
- Graceful degradation on network failures

Configuration options:
- telemetry.enabled (default: true)
- telemetry.interval.seconds (default: 86400)

Environment variables:
- LIFTBRIDGE_TELEMETRY_ENABLED
- LIFTBRIDGE_TELEMETRY_INTERVAL_SECONDS

Is enabled by default, but can be disable via config. See: https://docs.basekick.net/liftbridge/operations/telemetry