### PR TITLE
fix: create /tmp/liftbridge with proper ownership for non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN go build -mod=readonly \
 
 FROM alpine:latest
 RUN addgroup -g 1001 -S liftbridge && adduser -u 1001 -S liftbridge -G liftbridge
+RUN mkdir -p /tmp/liftbridge && chown liftbridge:liftbridge /tmp/liftbridge
 COPY --chown=liftbridge:liftbridge --from=build-base /workspace/liftbridge /usr/local/bin/liftbridge
 EXPOSE 9292
 VOLUME "/tmp/liftbridge/liftbridge-default"


### PR DESCRIPTION
The liftbridge container runs as the non-root liftbridge user (uid 1001), but when a Docker volume is mounted at /tmp/liftbridge, the mount point is created with root ownership. This causes a permission denied error on startup.

Creates /tmp/liftbridge with liftbridge:liftbridge ownership before the USER directive so the non-root user can write to mounted volumes.